### PR TITLE
Move Builder to dot and define ModelImage

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2017 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package dot
+
+// BuildImage applies the sequence of operations to an initial model
+// Image and returns the result.  If the old model is empty, the
+// initial model is guessed from the first operation/change
+//
+// Invalid operations are silently ignored.
+func (u Utils) BuildImage(old *ModelImage, ops []Operation) *ModelImage {
+	m := &ModelImage{}
+
+	if old != nil {
+		m.Model = old.Model
+		m.BasisID = old.BasisID
+	}
+
+	for _, op := range ops {
+		for _, ch := range op.Changes {
+			if m.Model == nil {
+				if len(ch.Path) == 0 && ch.Splice != nil && ch.Splice.After != nil {
+					data, ok := u.C.TryGet(ch.Splice.After)
+					if !ok {
+						continue
+					}
+					m.Model = data.Slice(0, 0)
+				} else if len(ch.Path) == 0 && ch.Set != nil {
+					m.Model = map[string]interface{}{}
+				} else {
+					continue
+				}
+			}
+			changes := []Change{ch}
+			if model, ok := u.TryApply(m.Model, changes); ok {
+				m.Model = model
+			}
+		}
+		m.BasisID = op.ID
+	}
+	return m
+}

--- a/builder_test.go
+++ b/builder_test.go
@@ -1,0 +1,127 @@
+// Copyright (C) 2017 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package dot_test
+
+import (
+	"github.com/dotchain/dot"
+	_ "github.com/dotchain/dot/encoding/sparse"
+	"testing"
+)
+
+func TestBuildImage_string(t *testing.T) {
+	splice := &dot.SpliceInfo{After: "Hello"}
+	ops := []dot.Operation{
+		{Changes: []dot.Change{{Splice: splice}}},
+	}
+	u := dot.Utils(dot.Transformer{})
+	result := u.BuildImage(nil, ops)
+
+	if !u.AreSame(result.Model, "Hello") {
+		t.Error("Unexpected output of splice", result.Model)
+	}
+}
+
+func TestBuildImage_array(t *testing.T) {
+	splice := &dot.SpliceInfo{After: []interface{}{"q", 42.0}}
+	ops := []dot.Operation{
+		{Changes: []dot.Change{{Splice: splice}}},
+	}
+	u := dot.Utils(dot.Transformer{})
+	result := u.BuildImage(nil, ops)
+
+	if !u.AreSame(result.Model, splice.After) {
+		t.Error("Unexpected output of splice", result.Model)
+	}
+}
+
+func TestBuildImage_sparse_array(t *testing.T) {
+	sparse := map[string]interface{}{
+		"dot:encoding": "SparseArray",
+		"dot:encoded":  []interface{}{5, 122},
+	}
+	splice := &dot.SpliceInfo{After: sparse}
+	ops := []dot.Operation{
+		{Changes: []dot.Change{{Splice: splice}}},
+	}
+	u := dot.Utils(dot.Transformer{})
+	result := u.BuildImage(nil, ops)
+
+	if !u.AreSame(result.Model, sparse) {
+		t.Error("Unexpected output of splice", result.Model)
+	}
+}
+
+func TestBuildImage_map(t *testing.T) {
+	set := &dot.SetInfo{Key: "hello", After: "world"}
+	ops := []dot.Operation{
+		{Changes: []dot.Change{{Set: set}}},
+	}
+	u := dot.Utils(dot.Transformer{})
+	result := u.BuildImage(nil, ops)
+
+	if !u.AreSame(result.Model, map[string]interface{}{"hello": "world"}) {
+		t.Error("Unexpected output of splice", result.Model)
+	}
+}
+
+func TestBuildImage_ignores_non_empty_path(t *testing.T) {
+	badSplice := &dot.SpliceInfo{After: "qqq"}
+	ops := []dot.Operation{
+		{Changes: []dot.Change{{Path: []string{"hello"}, Splice: badSplice}}},
+		{Changes: []dot.Change{{Path: []string{}, Splice: &dot.SpliceInfo{After: "good"}}}},
+	}
+
+	u := dot.Utils(dot.Transformer{})
+	result := u.BuildImage(nil, ops)
+
+	if !u.AreSame(result.Model, "good") {
+		t.Error("Unexpected output of splice", result.Model)
+	}
+}
+
+func TestBuildImage_ignores_bad_splice(t *testing.T) {
+	badSplice := &dot.SpliceInfo{After: 42}
+	ops := []dot.Operation{
+		{Changes: []dot.Change{{Splice: badSplice}}},
+		{Changes: []dot.Change{{Splice: &dot.SpliceInfo{After: "good"}}}},
+	}
+
+	u := dot.Utils(dot.Transformer{})
+	result := u.BuildImage(nil, ops)
+
+	if !u.AreSame(result.Model, "good") {
+		t.Error("Unexpected output of splice", result.Model)
+	}
+}
+
+func TestBuildImage_ignores_bad_move(t *testing.T) {
+	badMove := &dot.MoveInfo{Count: 1, Distance: 1, Offset: 2}
+	ops := []dot.Operation{
+		{Changes: []dot.Change{{Move: badMove}}},
+		{Changes: []dot.Change{{Splice: &dot.SpliceInfo{After: "good"}}}},
+	}
+
+	u := dot.Utils(dot.Transformer{})
+	result := u.BuildImage(nil, ops)
+
+	if !u.AreSame(result.Model, "good") {
+		t.Error("Unexpected output of splice", result.Model)
+	}
+}
+
+func TestBuildImage_ignores_bad_range(t *testing.T) {
+	badRange := &dot.RangeInfo{Count: 1, Offset: 2}
+	ops := []dot.Operation{
+		{Changes: []dot.Change{{Range: badRange}}},
+		{Changes: []dot.Change{{Splice: &dot.SpliceInfo{After: "good"}}}},
+	}
+
+	u := dot.Utils(dot.Transformer{})
+	result := u.BuildImage(nil, ops)
+
+	if !u.AreSame(result.Model, "good") {
+		t.Error("Unexpected output of splice", result.Model)
+	}
+}

--- a/log.go
+++ b/log.go
@@ -18,6 +18,13 @@ var ErrInvalidOperation = errors.New("invalid operation")
 // by the operation that is being appended.
 var ErrLogNeedsBackfilling = errors.New("log needs backfilling")
 
+// ModelImage represents a snapshot of the model after all operations
+// including and before the BasisID have been applied
+type ModelImage struct {
+	Model   interface{}
+	BasisID string
+}
+
 // Log represents a transformed sequence of operations for a
 // model that can be applied in sequence to reconstruct the
 // model.  The transformed operations are in the Rebased field.
@@ -47,8 +54,8 @@ var ErrLogNeedsBackfilling = errors.New("log needs backfilling")
 // This struct is not thread-safe.
 type Log struct {
 	Transformer
-	MinIndex     int
-	ModelImage   interface{}
+	MinIndex int
+	*ModelImage
 	Rebased      []Operation
 	MergeChains  [][]Operation
 	IDToIndexMap map[string]int

--- a/reconstruct_test.go
+++ b/reconstruct_test.go
@@ -41,11 +41,11 @@ func guessEmptyValue(ops []dot.Change) (interface{}, bool) {
 	}
 	op := ops[0]
 	u := dot.Utils(dot.Transformer{})
-	
+
 	if len(op.Path) > 0 {
 		panic("Unexpected path with empty before")
 	}
-	
+
 	if op.Splice != nil {
 		switch {
 		case op.Splice.Before != nil:

--- a/transformer.go
+++ b/transformer.go
@@ -13,9 +13,6 @@ import (
 // with same ID being merged against each other
 var ErrMergeWithSelf = errors.New("cannot merge an operation with itself")
 
-// ModelBuilder represents a function that can incrementally build a model
-type ModelBuilder func(oldModel interface{}, rebased []Operation) interface{}
-
 // Transformer provides the basic functionality to transform
 // Change and Operation values.
 type Transformer struct {


### PR DESCRIPTION
Move the snapshot/image format to dot as well as the model builder.  The rationale is that these are parts of the system that need to be compatible across other languages/clients and having it here makes that clear.