### PR TITLE
Remove direct use of reflect

### DIFF
--- a/deepequal.go
+++ b/deepequal.go
@@ -1,0 +1,12 @@
+// +build !tiny,!js
+
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+
+package dot
+
+import "reflect"
+
+var deepEqual = reflect.DeepEqual

--- a/encoding/catalog_reflect.go
+++ b/encoding/catalog_reflect.go
@@ -1,0 +1,69 @@
+// +build !js !tiny
+
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package encoding
+
+import "reflect"
+
+// RegisterConstructor registers the constructor of an encoding, typically
+// called during init of an encoding package.
+//
+// Note that the constructor provided as argument should have a
+// signature of the form:
+//     newMyType(c Catalog, m map[string]interface{}) MyType
+//
+// where MyType implements ArrayLike, ObjectLike or UniversalEncoding.
+//
+// This functions uses the reflect package to deal with all the
+// variations but to avoid the cost of pulling in the reflect package,
+// this API is not available in the js builds.
+func (c Catalog) RegisterConstructor(name string, fn interface{}) {
+	fType := reflect.TypeOf(fn)
+	if fType.Kind() != reflect.Func {
+		panic(errNotFunction)
+	}
+
+	if fType.NumIn() != 2 {
+		panic(errNumArgs)
+	}
+
+	if fType.In(0) != reflect.TypeOf(c) {
+		panic(errFirstArgMustBeCatalog)
+	}
+
+	var dummy map[string]interface{}
+	if fType.In(1) != reflect.TypeOf(dummy) {
+		panic(errSecondArgMustBeMap)
+	}
+
+	if fType.NumOut() != 1 {
+		panic(errSingleReturnValue)
+	}
+
+	resultType := fType.Out(0)
+	zero := reflect.Zero(resultType).Interface()
+	if _, ok := zero.(ArrayLike); ok {
+		ctor := func(cat Catalog, m map[string]interface{}) UniversalEncoding {
+			args := []reflect.Value{reflect.ValueOf(cat), reflect.ValueOf(m)}
+			val := reflect.ValueOf(fn).Call(args)[0].Interface()
+			return enrichArrayIfNeeded(val.(ArrayLike))
+		}
+		c.RegisterTypeConstructor(name, resultType, ctor)
+		return
+	}
+
+	if _, ok := zero.(ObjectLike); ok {
+		ctor := func(cat Catalog, m map[string]interface{}) UniversalEncoding {
+			args := []reflect.Value{reflect.ValueOf(cat), reflect.ValueOf(m)}
+			val := reflect.ValueOf(fn).Call(args)[0].Interface()
+			return enrichObjectIfNeeded(val.(ObjectLike))
+		}
+		c.RegisterTypeConstructor(name, resultType, ctor)
+		return
+	}
+
+	panic(errUnexpectedType)
+}

--- a/encoding/rich_text/rich_text.go
+++ b/encoding/rich_text/rich_text.go
@@ -14,7 +14,12 @@ import (
 )
 
 func init() {
-	encoding.Default.RegisterConstructor("RichText", NewArray)
+	ctor := func(c encoding.Catalog, m map[string]interface{}) encoding.UniversalEncoding {
+		return NewArray(c, m)
+	}
+
+	key := "github.com/dotchain/dot/encoding/rich_text"
+	encoding.Default.RegisterTypeConstructor("RichText", key, ctor)
 }
 
 // Array is a run length encoding of an attributed string

--- a/tiny.go
+++ b/tiny.go
@@ -1,0 +1,10 @@
+// +build tiny js
+
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+package dot
+
+func deepEqual(i1, i2 interface{}) bool {
+	return true
+}

--- a/utils.go
+++ b/utils.go
@@ -7,8 +7,6 @@ package dot
 import (
 	"encoding/json"
 	"github.com/dotchain/dot/encoding"
-	"log"
-	"reflect"
 	"strconv"
 )
 
@@ -30,7 +28,7 @@ func (u Utils) AreSame(i1, i2 interface{}) bool {
 	}
 
 	if !ok1 || !ok2 {
-		return reflect.DeepEqual(i1, i2)
+		return deepEqual(i1, i2)
 	}
 
 	if x1 == nil {
@@ -85,7 +83,7 @@ func (u Utils) TryApply(obj interface{}, changes []Change) (result interface{}, 
 	// actual client bug.
 	defer func() {
 		if r := recover(); r != nil {
-			log.Println("TryApply panic'ed", r)
+			// log.Println("TryApply panic'ed", r)
 			result = nil
 			ok = false
 		}
@@ -109,7 +107,7 @@ func (u Utils) TryApply(obj interface{}, changes []Change) (result interface{}, 
 				r := change.Range
 				return u.tryApplyRange(input, r.Offset, r.Count, r.Changes)
 			}
-			log.Println("Ignoring empty", input)
+			// log.Println("Ignoring empty", input)
 			return input, true
 		})
 		if !ok {


### PR DESCRIPTION
Reflect is still used indirectly via encoding/json and sort.  Those will need to be removed in separate steps