### PR TITLE
Refactor dot into changes/ rt/ etc

### DIFF
--- a/changes/array_test.go
+++ b/changes/array_test.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package changes_test
+
+import (
+	"fmt"
+	"github.com/dotchain/dot/changes"
+)
+
+// A implements the Value interface over a slice of values
+type A []changes.Value
+
+func (a A) Slice(offset, count int) changes.Value {
+	return a[offset : offset+count]
+}
+
+func (a A) Count() int {
+	return len(a)
+}
+
+func (a A) Apply(c changes.Change) changes.Value {
+	switch c := c.(type) {
+	case nil:
+		return a
+	case changes.Replace:
+		if c.IsDelete {
+			return changes.Nil
+		}
+		return c.After
+	case changes.Splice:
+		after := c.After.(A)
+		result := append(a[:c.Offset:c.Offset], after...)
+		return A(append(result, a[c.Offset+c.Before.Count():]...))
+	case changes.Move:
+		ox, cx, dx := c.Offset, c.Count, c.Distance
+		if dx < 0 {
+			ox, cx, dx = ox+dx, -dx, cx
+		}
+		l, m1, m2, r := a[:ox:ox], a[ox:ox+cx], a[ox+cx:ox+cx+dx], a[ox+cx+dx:]
+		return A(append(append(append(l, m2...), m1...), r...))
+	case changes.ChangeSet:
+		v := changes.Value(a)
+		for _, cx := range c {
+			if cx != nil {
+				if v == nil {
+					fmt.Println("Unexpected nil v", cx)
+				}
+				v = v.Apply(cx)
+			}
+		}
+		return v
+	case changes.PathChange:
+		if len(c.Path) == 0 {
+			return a.Apply(c.Change)
+		}
+		idx := c.Path[0].(int)
+		clone := append([]changes.Value(nil), a...)
+		clone[idx] = clone[idx].Apply(changes.PathChange{c.Path[1:], c.Change})
+		return A(clone)
+	default:
+		panic(fmt.Sprintf("Unexpected Apply %#v", c))
+	}
+}

--- a/changes/assorted_test.go
+++ b/changes/assorted_test.go
@@ -1,0 +1,124 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package changes_test
+
+import (
+	"github.com/dotchain/dot/changes"
+	"reflect"
+	"testing"
+)
+
+// The random set of tests here are more targeted to cover some rarely
+// used codepaths.
+
+func TestNilChangeSet(t *testing.T) {
+	_, cx := changes.ChangeSet(nil).Merge(changes.Move{0, 5, 1})
+	if cx != nil {
+		t.Error("Unexpected non nil cx", cx)
+	}
+
+	_, cx = changes.ChangeSet{nil}.Merge(changes.Move{0, 5, 1})
+	if cx != nil {
+		t.Error("Unexpected non nil cx", cx)
+	}
+
+	if x := changes.ChangeSet(nil).Revert(); x != nil {
+		t.Error("Unexpected non nil x", x)
+	}
+
+	if x := (changes.ChangeSet{nil}).Revert(); x != nil {
+		t.Error("Unexpected non nil x", x)
+	}
+}
+
+func TestSingleChangeSet(t *testing.T) {
+	splice1 := changes.Splice{0, S("ab"), S("cd")}
+	splice2 := changes.Splice{5, S("ef"), S("gh")}
+	cx := changes.ChangeSet{splice1}
+	if _, x := cx.Merge(splice2); x != splice1 {
+		t.Error("Unexpected single merge behavior", x)
+	}
+
+	if cx.Revert() != splice1.Revert() {
+		t.Error("Unexpected revert behavior", cx.Revert())
+	}
+
+	if x, _ := splice2.Merge(cx); x != splice1 {
+		t.Error("Unexpected single merge behavior", x)
+	}
+}
+
+func TestMultiChangeSet(t *testing.T) {
+	splice1 := changes.Splice{0, S("ab"), S("cd")}
+	splice2 := changes.Splice{5, S("ef"), S("gh")}
+	splice3 := changes.Splice{10, S("a"), S("z")}
+	cx := changes.ChangeSet{splice1, splice2}
+	if x, _ := splice3.Merge(cx); !reflect.DeepEqual(x, cx) {
+		t.Error("Unexpected multi merge", x)
+	}
+}
+
+func TestChangeMethod(t *testing.T) {
+	r := &changes.Replace{Before: S(""), After: S("a")}
+	s := &changes.Splice{0, S(""), S("a")}
+	m := &changes.Move{0, 5, 1}
+	if r.Change() != *r || s.Change() != *s || m.Change() != *m {
+		t.Error("Unexpected change failure")
+	}
+}
+
+func TestEmptyAtomicAndUnexpectedChange(t *testing.T) {
+	expectPanic := func(msg string, fn func()) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("Failed to panic", msg)
+			}
+		}()
+		fn()
+	}
+	expectPanic("Nil.Slice", func() { changes.Nil.Slice(0, 0) })
+	expectPanic("Nil.Count", func() { changes.Nil.Count() })
+	expectPanic("Nil.Count", func() { changes.Nil.Apply(changes.Replace{IsDelete: true}) })
+	expectPanic("Nil.Apply", func() { changes.Nil.Apply(changes.Move{0, 5, 1}) })
+
+	if x := changes.Nil.Apply(changes.ChangeSet{changes.PathChange{}}); x != changes.Nil {
+		t.Error("Unexpected apply(...)", x)
+	}
+
+	x := changes.Nil.Apply(changes.Replace{IsInsert: true, Before: changes.Nil, After: S("a")})
+	if x != S("a") {
+		t.Error("Unexpected replace", x)
+	}
+
+	a := changes.Atomic{nil}
+	expectPanic("Atomic.Slice", func() { a.Slice(0, 0) })
+	expectPanic("Atomic.Count", func() { a.Count() })
+	expectPanic("Atomic.Count", func() { a.Apply(changes.Replace{IsInsert: true}) })
+	expectPanic("Atomic.Apply", func() { a.Apply(changes.Move{0, 5, 1}) })
+
+	if x := a.Apply(changes.ChangeSet{changes.PathChange{}}); x != a {
+		t.Error("Unexpected apply(...)", x)
+	}
+
+	x = a.Apply(changes.Replace{Before: a, After: S("a")})
+	if x != S("a") {
+		t.Error("Unexpected replace", x)
+	}
+
+	z := myChange{}
+	expectPanic("myChange1", func() { (changes.Replace{Before: S(""), After: S("a")}).Merge(z) })
+	expectPanic("myChange2", func() { (changes.Splice{0, S(""), S("a")}).Merge(z) })
+	expectPanic("myChange3", func() { (changes.Move{0, 5, 1}).Merge(z) })
+}
+
+type myChange struct{}
+
+func (m myChange) Merge(other changes.Change) (ox, cx changes.Change) {
+	return nil, nil
+}
+
+func (m myChange) Revert() changes.Change {
+	return nil
+}

--- a/changes/atomic.go
+++ b/changes/atomic.go
@@ -1,0 +1,47 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package changes
+
+// Atomic is an atomic Value. It can wrap any particular value and can
+// be used in the Before, After fields of Replace or Splice.
+type Atomic struct {
+	Value interface{}
+}
+
+// Slice should not be called on Atomic values
+func (a Atomic) Slice(offset, count int) Value {
+	panic("Slice should  not be called on atomic values")
+}
+
+// Count should not be called on Atomic values
+func (a Atomic) Count() int {
+	panic("Count should not be called on atomic values")
+}
+
+// Apply only accepts one type of change: one that Replace's the
+// value.
+func (a Atomic) Apply(c Change) Value {
+	switch c := c.(type) {
+	case nil:
+		return a
+	case Replace:
+		if !c.IsInsert {
+			return c.After
+		}
+	case PathChange:
+		if len(c.Path) == 0 {
+			return a.Apply(c.Change)
+		}
+	case ChangeSet:
+		v := Value(a)
+		for _, cx := range c {
+			if cx != nil {
+				v = v.Apply(cx)
+			}
+		}
+		return v
+	}
+	panic("Unexpected change applied on atomic")
+}

--- a/changes/changes.go
+++ b/changes/changes.go
@@ -1,0 +1,159 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+// Package changes implements the core mutation types for OT.
+//
+// The three basic types are Replace, Splice and Move. Replace
+// replaces a value altogether while Splice replaces a sub-sequence in
+// an array-like object and Move shuffles a sub-sequence.
+//
+// ChangeSet allows a set of mutations to be grouped together.
+//
+// PathChange allows a mutation to refer to a "path".  This is useful
+// when mutating a JSON-like object composed of arrays and maps. The
+// path is simply how a particular node is to be traversed, with keys
+// and indices in the order in which they appear.
+//
+// Custom changes can be defined so long as it follows the Change
+// interface and also implements a "ReverseMerge" method. See
+// https://godoc.org/github.com/dotchain/dot/changes/x/rt#Run for a
+// custom change type.
+//
+// The Replace and Splice change both expect the Before, After fields
+// to be non-nil Value implementations.  Nil is an example empty value
+// and Atomic can be used to wrap any immutable value.
+//
+// Any custom Value implementation should implement the Value
+// interface.  See https://godoc.org/github.com/dotchain/dot/types
+// for a set of custom value types
+package changes
+
+// Change represents an OT-compatible mutation of the virtual JSON.
+//
+// Note that it is legal for a change to be nil. It represents a
+// noop.
+type Change interface {
+	// Merge takes the current change and another change that were
+	// both applied to the same virtual JSON and returns
+	// transformed versions such that:
+	//
+	//     c + otherx = other + cx
+	//
+	// Otherx captures the intent behind other and cx captures the
+	// intent behind the current change.  The equation above
+	// guarantees that the combined intent can be achieved by
+	// applying the transformed changes on top of the local
+	// change.
+	//
+	// Note that there is no requirement that c.Merge(other) and
+	// other.Merge(c) should both yield the same transforms. This
+	// requires that for correctness, there must be a clear way to
+	// decide which change is the receiver and which is the param.
+	Merge(other Change) (otherx, cx Change)
+
+	// Revert returns the opposite effect of the current
+	// change. If applied directly after the current change it
+	// should undo the effect of the current change.
+	Revert() Change
+}
+
+// Value represents an immutable JSON object that can apply
+// changes.
+type Value interface {
+	// Slice should only be called on collection-like objects such
+	// as the Before/After fields of a Splice. Note that unlike
+	// Go's slice notation, the arguments are offset and count.
+	Slice(offset, count int) Value
+
+	// Count should noly be called on collection-like objects such
+	// as the Before/After fields of a Splice. It returns the size
+	// of the collection.
+	Count() int
+
+	// Apply applies the specified change on the object and
+	// returns the updated value.
+	Apply(c Change) Value
+}
+
+// ChangeSet represents a collection of changes. It implements the
+// Change interface thereby allowing merging groups of changes against
+// each other.
+type ChangeSet []Change
+
+// Merge implements Change.Merge.
+func (c ChangeSet) Merge(other Change) (otherx, cx Change) {
+	idx, results := 0, make([]Change, len(c))
+	for _, elt := range c {
+		if elt != nil {
+			other, results[idx] = elt.Merge(other)
+			if results[idx] != nil {
+				idx++
+			}
+		}
+	}
+	switch idx {
+	case 0:
+		return other, nil
+	case 1:
+		return other, results[0]
+	}
+	return other, ChangeSet(results[:idx])
+}
+
+// ReverseMerge is like merge except with receiver and args inverted
+func (c ChangeSet) ReverseMerge(other Change) (otherx, cx Change) {
+	idx, results := 0, make([]Change, len(c))
+	for _, elt := range c {
+		l, r := elt, other
+		if other != nil {
+			l, r = other.Merge(elt)
+		}
+		results[idx], other = l, r
+		if l != nil {
+			idx++
+		}
+	}
+	switch idx {
+	case 0:
+		return other, nil
+	case 1:
+		return other, results[0]
+	}
+	return other, ChangeSet(results[:idx])
+}
+
+// Revert implements Change.Revert.
+func (c ChangeSet) Revert() Change {
+	idx, results := 0, make([]Change, len(c))
+	for kk := range c {
+		if elt := c[len(c)-kk-1]; elt != nil {
+			results[idx] = elt.Revert()
+			idx++
+		}
+	}
+	switch idx {
+	case 0:
+		return nil
+	case 1:
+		return results[0]
+	}
+	return ChangeSet(results[:idx])
+}
+
+type revMerge interface {
+	ReverseMerge(o Change) (ox, mx Change)
+}
+
+// helper method
+type changeable interface {
+	Change() Change
+}
+
+func change(x, y changeable) (Change, Change) {
+	return x.Change(), y.Change()
+}
+
+func swap(x, y Change) (Change, Change) {
+	return y, x
+}

--- a/changes/convergence_test.go
+++ b/changes/convergence_test.go
@@ -1,0 +1,84 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package changes_test
+
+import (
+	"github.com/dotchain/dot/changes"
+	"testing"
+)
+
+func validateMerge(t *testing.T, initial changes.Value, left, right changes.Change) {
+	leftx, rightx := left.Merge(right)
+	lval := initial.Apply(changes.ChangeSet{left, leftx})
+	rval := initial.Apply(changes.ChangeSet{right, rightx})
+	if lval != rval {
+		t.Error("Diverged", lval, rval, left, right)
+	}
+}
+
+func TestConvergenceNonEmptyInitial(t *testing.T) {
+	ForEachChange(S("xyz"), func(initial changes.Value, left changes.Change) {
+		ForEachChange(S("ab"), func(_ changes.Value, right changes.Change) {
+			validateMerge(t, initial, left, right)
+			validateMerge(t, initial, right, left)
+		})
+	})
+}
+
+func TestConvergenceEmptyInitial(t *testing.T) {
+	initial := changes.Nil
+	cx := []changes.Change{
+		changes.Replace{IsInsert: true, Before: changes.Nil, After: S("hello")},
+		changes.Replace{IsInsert: true, Before: changes.Nil, After: S("world")},
+	}
+	for _, left := range cx {
+		for _, right := range cx {
+			validateMerge(t, initial, left, right)
+		}
+	}
+}
+
+func TestConvergenceChangeSet(t *testing.T) {
+	initial := S("hello")
+	left := changes.ChangeSet{
+		changes.Replace{IsDelete: true, Before: initial, After: changes.Nil},
+		changes.Replace{IsInsert: true, Before: changes.Nil, After: S("World")},
+		changes.Splice{5, S(""), S("!")},
+	}
+	right := changes.ChangeSet{
+		changes.Splice{0, S("h"), S("j")},
+		changes.Splice{5, S(""), S(" shots!")},
+	}
+	validateMerge(t, initial, left, right)
+}
+
+func ForEachChange(replacement changes.Value, fn func(initial changes.Value, c changes.Change)) {
+	initial := S("abcdef")
+	fn(initial, changes.ChangeSet{nil})
+	fn(initial, changes.Replace{Before: initial, After: replacement})
+	fn(initial, changes.Replace{Before: initial, IsDelete: true})
+	fn(initial, changes.Move{0, 5, 0})
+	fn(initial, changes.Move{5, 0, 1})
+	for offset := 0; offset <= initial.Count(); offset++ {
+		for count := 0; count <= initial.Count()-offset; count++ {
+			before := initial.Slice(offset, count)
+			if count > 0 {
+				fn(initial, changes.Splice{offset, before, S("")})
+			}
+			fn(initial, changes.Splice{offset, before, replacement})
+		}
+	}
+
+	count := replacement.Count()
+	for offset := 0; offset <= initial.Count()-count; offset++ {
+		for dest := 0; dest <= initial.Count(); dest++ {
+			if dest < offset {
+				fn(initial, changes.Move{offset, count, dest - offset})
+			} else if dest > offset+count {
+				fn(initial, changes.Move{offset, count, dest - offset - count})
+			}
+		}
+	}
+}

--- a/changes/correctness_test.go
+++ b/changes/correctness_test.go
@@ -1,0 +1,66 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package changes_test
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/test/seqtest"
+	"testing"
+)
+
+// These sequences are a bit odd to start with, so the specific
+// outcomes are probably ok.  Should just rewrite the dataset for
+// this. Most of these seem like a problem with splices adjacent to
+// the move wrongly moving along with the move.
+var knownFailures = map[string]string{
+	"-abc[123]de4|56fg- x -abc1|23de[456]fg-": "-abcde145623fg-",
+	"-abc123[|d]456f- x -abc123[456]f|-":      "-abc123fd456-",
+	"-abc123[|d]456f- x -abc|123[456]f-":      "-abcd456123f-",
+	"-abc123[|d]456f- x -ab|c123[456]f-":      "-abd456c123f-",
+	"-ab|c[123]ef- x -abc123[|d]ef-":          "-ab123dcef-",
+	"-abc[123]e|f- x -abc123[|d]ef-":          "-abce123df-",
+	"-abc[1234|d]ef- x -ab|c[1234]ef-":        "-ab1234cdef-",
+	"-abc[1234|]ef- x -ab|c[1234]ef-":         "-ab1234cef-",
+	"-abc[|d]ef- x -a|b[ce]f-":                "-acdebf-",
+}
+
+func TestCorrectnessOfStandardSequences(t *testing.T) {
+	s := seqTester{}
+	seqtest.ForEachTest(s, s, func(name, initial string, l, r interface{}, merged string) {
+		if l == nil || r == nil {
+			return
+		}
+		t.Run(name, func(t *testing.T) {
+			left := l.(changes.Change)
+			right := r.(changes.Change)
+			leftx, rightx := left.Merge(right)
+			lval := S(initial).Apply(changes.ChangeSet{left, leftx})
+			rval := S(initial).Apply(changes.ChangeSet{right, rightx})
+			if lval != rval {
+				t.Error("Diverged", lval, rval, left, right)
+			}
+
+			if lval != S(merged) && lval != S(knownFailures[name]) {
+				t.Error("Converged on unexpected value", lval, merged, knownFailures[name])
+			}
+		})
+	})
+}
+
+type seqTester struct{}
+
+func (s seqTester) Splice(initial string, offset, count int, replacement string) interface{} {
+	before := S(initial[offset : offset+count])
+	after := S(replacement)
+	return changes.Splice{offset, before, after}
+}
+
+func (s seqTester) Move(initial string, offset, count, distance int) interface{} {
+	return changes.Move{offset, count, distance}
+}
+
+func (s seqTester) Range(initial string, offset, count int, attribute string) interface{} {
+	return nil
+}

--- a/changes/empty.go
+++ b/changes/empty.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package changes
+
+// Nil represents an empty value. It can be used with Replace or
+// Splice to indicate that Before or After is empty. The only
+// operation that can be applied is a Replace.  Count and Slice cannot
+// be called on it.
+var Nil = empty{}
+
+// empty represents an empty value. This should be used instead of nil
+// with Replace. The only operation it supports is replacing with
+// another value.
+type empty struct{}
+
+// Slice should not be called on empty
+func (e empty) Slice(offset, count int) Value {
+	panic("Unexpected Slice call on empty value")
+}
+
+// Count should not be called on empty
+func (e empty) Count() int {
+	panic("Unexpected Count call on empty value")
+}
+
+// Apply can be called on empty but it only supports
+// Replace{IsInsert:true} type changes.
+func (e empty) Apply(c Change) Value {
+	switch c := c.(type) {
+	case nil:
+		return e
+	case Replace:
+		if c.IsInsert && c.After != Nil {
+			return c.After
+		}
+	case PathChange:
+		if len(c.Path) == 0 {
+			return e.Apply(c.Change)
+		}
+	case ChangeSet:
+		v := Value(e)
+		for _, cx := range c {
+			if cx != nil {
+				v = v.Apply(cx)
+			}
+		}
+		return v
+	}
+	panic("Unexpected change applied on empty")
+}

--- a/changes/move.go
+++ b/changes/move.go
@@ -1,0 +1,272 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package changes
+
+// Move represents a shuffling of some elements (specified  by Offset
+// and Count) over to a different spot (specified by Distance, which
+// can be negative to indicate a move over to the left).
+type Move struct {
+	Offset, Count, Distance int
+}
+
+// Revert reverts the move.
+func (m Move) Revert() Change {
+	return Move{m.Offset + m.Distance, m.Count, -m.Distance}
+}
+
+// MergeReplace merges a move against a Replace.  The replace always wins
+func (m Move) MergeReplace(other Replace) (other1 *Replace, m1 *Splice) {
+	other.Before = other.Before.Apply(m)
+	return &other, nil
+}
+
+// MergeSplice merges a splice with a move.
+func (m Move) MergeSplice(o Splice) (Change, Change) {
+	x, y := o.MergeMove(m)
+	return y, x
+}
+
+// MergeMove merges a move against another Move
+func (m Move) MergeMove(o Move) (ox []Move, mx []Move) {
+	if m == o {
+		return nil, nil
+	}
+
+	if m.Distance == 0 || m.Count == 0 || o.Distance == 0 || o.Count == 0 {
+		return []Move{o}, []Move{m}
+	}
+
+	if m.Offset >= o.Offset+o.Count || o.Offset >= m.Offset+m.Count {
+		return m.mergeMoveNoOverlap(o)
+	}
+
+	if m.Offset <= o.Offset && m.Offset+m.Count >= o.Offset+o.Count {
+		return m.mergeMoveContained(o)
+	}
+
+	if m.Offset >= o.Offset && m.Offset+m.Count <= o.Offset+o.Count {
+		return m.swap(o.mergeMoveContained(m))
+	}
+
+	if m.Offset < o.Offset {
+		return m.mergeMoveRightOverlap(o)
+	}
+
+	return m.swap(o.mergeMoveRightOverlap(m))
+}
+
+func (m Move) mergeMoveNoOverlap(o Move) (ox, mx []Move) {
+	mdest, odest := m.dest(), o.dest()
+
+	if !m.contains(odest) && !o.contains(mdest) {
+		return m.mergeMoveNoOverlapNoDestMixups(o)
+	}
+
+	if m.contains(odest) && o.contains(mdest) {
+		return m.mergeMoveNoOverlapMixedDests(o)
+	}
+
+	if o.contains(mdest) {
+		return m.swap(o.mergeMoveNoOverlap(m))
+	}
+
+	return m.mergeMoveNoOverlapContainedDest(o)
+}
+
+func (m Move) mergeMoveNoOverlapContainedDest(o Move) (ox, mx []Move) {
+	mdest, odest := m.dest(), o.dest()
+
+	mdestNew := mdest
+	if mdest >= odest && mdest <= o.Offset {
+		mdestNew += o.Count
+	} else if mdest > o.Offset && mdest <= odest {
+		mdestNew -= o.Count
+	}
+
+	m1 := m
+	if o.Offset <= m.Offset {
+		m1.Offset -= o.Count
+	}
+	m1.Count = m.Count + o.Count
+	if mdestNew <= m1.Offset {
+		m1.Distance = mdestNew - m1.Offset
+	} else {
+		m1.Distance = mdestNew - m1.Offset - m1.Count
+	}
+
+	if o.Offset > m.Offset && o.Offset < mdest {
+		o.Offset -= m.Count
+	} else if o.Offset >= mdest && o.Offset < m.Offset {
+		o.Offset += m.Count
+	}
+	odest += m.Distance
+	if odest <= o.Offset {
+		o.Distance = odest - o.Offset
+	} else {
+		o.Distance = odest - o.Offset - o.Count
+	}
+
+	return []Move{o}, []Move{m1}
+}
+
+func (m Move) mergeMoveNoOverlapNoDestMixups(o Move) (ox, mx []Move) {
+	mdest, odest := m.dest(), o.dest()
+	o1 := Move{Offset: m.mapPoint(o.Offset), Count: o.Count}
+	o1 = o1.withDest(m.mapPoint(odest))
+	if odest == mdest {
+		o1 = o1.withDest(m.Offset + m.Distance)
+	}
+
+	m1 := Move{Offset: o.mapPoint(m.Offset), Count: m.Count}
+	m1 = m1.withDest(o.mapPoint(mdest))
+
+	return []Move{o1}, []Move{m1}
+}
+
+func (m Move) mergeMoveNoOverlapMixedDests(o Move) (ox, mx []Move) {
+	var oleft, oright Move
+	mdest, odest := m.dest(), o.dest()
+
+	oleft.Count = mdest - o.Offset
+	oright.Count = o.Count - oleft.Count
+	oleft.Offset = m.Offset + m.Distance - oleft.Count
+	oright.Offset = m.Offset + m.Distance + m.Count
+	oleft.Distance = odest - m.Offset
+	oright.Distance = odest - m.Offset - m.Count
+	ox = []Move{oleft, oright}
+
+	distance := o.Offset - m.Offset - m.Count
+	if distance < 0 {
+		distance = -(m.Offset - o.Offset - o.Count)
+	}
+	mx = []Move{{
+		Offset:   o.Offset + o.Distance - (odest - m.Offset),
+		Count:    m.Count + o.Count,
+		Distance: distance,
+	}}
+	return ox, mx
+}
+
+func (m Move) mergeMoveRightOverlap(o Move) ([]Move, []Move) {
+	overlapSize := m.Offset + m.Count - o.Offset
+	overlapUndo := Move{Offset: o.Offset + o.Distance, Count: overlapSize}
+	non := Move{Offset: o.Offset + overlapSize, Count: o.Count - overlapSize}
+
+	if o.Distance > 0 {
+		overlapUndo.Distance = -o.Distance
+		non.Distance = o.Distance
+	} else {
+		overlapUndo.Distance = o.Count - overlapSize - o.Distance
+		non.Distance = o.Distance - overlapSize
+	}
+	l, r := m.mergeMoveNoOverlap(non)
+	return l, append([]Move{overlapUndo}, r...)
+}
+
+func (m Move) mergeMoveContained(o Move) ([]Move, []Move) {
+	odest := o.dest()
+	ox := o
+	ox.Offset += m.Distance
+	if m.Offset <= odest && odest <= m.Offset+m.Count {
+		return []Move{ox}, []Move{m}
+	}
+
+	if odest == m.dest() {
+		ox = ox.withDest(m.Offset + m.Distance)
+		mx := m
+		mx.Count -= o.Count
+		if o.Distance < 0 {
+			mx.Offset += o.Count
+		}
+		mx = mx.withDest(o.Offset + o.Count + o.Distance)
+		return []Move{ox}, []Move{mx}
+	}
+
+	ox = ox.withDest(m.mapPoint(odest))
+
+	mx := m
+	mx.Offset = o.mapPoint(m.Offset)
+	mx.Count = m.Count - o.Count
+	mx = mx.withDest(o.mapPoint(m.dest()))
+
+	return []Move{ox}, []Move{mx}
+}
+
+func (m Move) mapPoint(idx int) int {
+	if idx >= m.Offset+m.Distance && idx <= m.Offset {
+		return idx + m.Count
+	}
+	if idx >= m.Offset+m.Count && idx < m.Offset+m.Count+m.Distance {
+		return idx - m.Count
+	}
+	return idx
+}
+
+func (m Move) dest() int {
+	if m.Distance < 0 {
+		return m.Offset + m.Distance
+	}
+	return m.Offset + m.Distance + m.Count
+}
+
+func (m Move) withDest(dest int) Move {
+	m.Distance = dest - m.Offset - m.Count
+	if m.Distance < 0 {
+		m.Distance = dest - m.Offset
+	}
+	return m
+}
+
+func (m Move) contains(idx int) bool {
+	return idx > m.Offset && idx < m.Offset+m.Count
+}
+
+func (m Move) swap(l, r []Move) ([]Move, []Move) {
+	return r, l
+}
+
+func movesToChange(m []Move) Change {
+	result := make([]Change, len(m))
+	for _, mm := range m {
+		if mm.Count != 0 && mm.Distance != 0 {
+			result = append(result, mm)
+		}
+	}
+	switch len(result) {
+	case 0:
+		return nil
+	case 1:
+		return result[0]
+	}
+	return ChangeSet(result)
+}
+
+// Merge implements the Change.Merge method
+func (m Move) Merge(other Change) (otherx, cx Change) {
+	if other == nil {
+		return nil, m
+	}
+
+	switch o := other.(type) {
+	case Replace:
+		return change(m.MergeReplace(o))
+	case Splice:
+		return m.MergeSplice(o)
+	case Move:
+		l, r := m.MergeMove(o)
+		return movesToChange(l), movesToChange(r)
+	case revMerge:
+		return swap(o.ReverseMerge(m))
+	}
+	panic("Unexpected change")
+}
+
+// Change returns either nil or the underlying Move as a change.
+func (m *Move) Change() Change {
+	if m == nil {
+		return nil
+	}
+	return *m
+}

--- a/changes/path_test.go
+++ b/changes/path_test.go
@@ -1,0 +1,207 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package changes_test
+
+import (
+	"github.com/dotchain/dot/changes"
+	"reflect"
+	"testing"
+)
+
+type Path []interface{}
+
+func TestPathChangeRevert(t *testing.T) {
+	pc := changes.PathChange{Path{"a"}, changes.Move{1, 2, 3}}
+	expected := changes.PathChange{Path{"a"}, pc.Change.Revert()}
+	if !reflect.DeepEqual(pc.Revert(), expected) {
+		t.Error("Unexpected revert", pc.Revert())
+	}
+
+	pc = changes.PathChange{Path{"a"}, nil}
+	if pc.Revert() != nil {
+		t.Error("Unexpected revert", pc.Revert())
+	}
+}
+
+func TestPathChangeReverseMergeSimple(t *testing.T) {
+	pc := changes.PathChange{nil, changes.Replace{Before: S("ab"), After: S("bc")}}
+	o := changes.PathChange{nil, changes.Move{1, 1, -1}}
+
+	lx, rx := pc.ReverseMerge(o)
+	lx = simplify(lx)
+	rx = simplify(rx)
+	if lx != nil || rx != (changes.Replace{Before: S("ba"), After: S("bc")}) {
+		t.Error("Unexpected merge output", lx, rx)
+	}
+}
+
+func TestPathChangeDifferentPaths(t *testing.T) {
+	left := changes.Replace{Before: S("a"), After: S("b")}
+	right := changes.Replace{Before: S("c"), After: S("d")}
+	l := changes.PathChange{Path{"q", 2, "a"}, left}
+	r := changes.PathChange{Path{"q", 9, "a"}, right}
+	validateMergeResults(t, l, r, r, l)
+}
+
+func TestPathChangeNil(t *testing.T) {
+	left := changes.Replace{Before: S("a"), After: S("b")}
+	l := changes.PathChange{Path{"q", 9, "aa"}, left}
+	r := changes.PathChange{Path{"q", 9}, nil}
+	validateMergeResults(t, l, r, nil, l)
+}
+
+func TestPathChangeMergeReplace(t *testing.T) {
+	initial := A{A{S("a"), S("b")}, A{S("c"), S("d")}}
+	left := changes.Replace{Before: initial, After: A{S("Boo")}}
+
+	right := changes.PathChange{Path{0}, changes.Replace{Before: initial[0], After: A{S("")}}}
+	lexpected := changes.Change(nil)
+	rexpected := changes.Replace{Before: initial.Apply(right), After: left.After}
+	validateMergeResults(t, left, right, lexpected, rexpected)
+}
+
+func TestPathChangeMergeSpliceLeft(t *testing.T) {
+	initial := A{A{S("a"), S("b")}, A{S("c"), S("d")}}
+	left := changes.Splice{1, initial.Slice(1, 1), S("Boo")}
+
+	right := changes.PathChange{Path{0}, changes.Replace{Before: initial[0], After: S("")}}
+
+	validateMergeResults(t, left, right, right, left)
+}
+
+func TestPathChangeMergeSpliceMiddle(t *testing.T) {
+	initial := A{A{S("a"), S("b")}, A{S("c"), S("d")}}
+	left := changes.Splice{1, initial.Slice(1, 1), A{S("Boo")}}
+
+	right := changes.PathChange{Path{1}, changes.Replace{Before: initial[1], After: S("zoog")}}
+
+	lexpected := changes.Change(nil)
+	rexpected := changes.Splice{1, initial.Apply(right).Slice(1, 1), left.After}
+
+	validateMergeResults(t, left, right, lexpected, rexpected)
+}
+
+func TestPathChangeMergeSpliceRight(t *testing.T) {
+	initial := A{A{S("a"), S("b")}, A{S("c"), S("d")}}
+	left := changes.Splice{0, initial.Slice(0, 1), A{S("Boo"), S("Boo2"), S("Boo3")}}
+
+	right := changes.PathChange{Path{1, 0}, changes.Replace{Before: S("c"), After: S("zoog")}}
+
+	lexpected := changes.PathChange{Path{3, 0}, changes.Replace{Before: S("c"), After: S("zoog")}}
+	rexpected := left
+
+	validateMergeResults(t, left, right, lexpected, rexpected)
+}
+
+func TestPathChangeMergeMoveRight(t *testing.T) {
+	initial := A{A{S("A"), S("a")}, A{S("B"), S("b")}, A{S("C"), S("c")}, A{S("D"), S("d")}, A{S("E"), S("e")}, A{S("F"), S("f")}}
+	left := changes.Move{1, 2, 1} // abcdef => adbcef
+	for idx := 0; idx < initial.Count(); idx++ {
+		before := S(("abcdef")[idx : idx+1])
+		re := changes.Replace{Before: before, After: S("boo")}
+		right := changes.PathChange{Path{idx, 1}, re}
+		lexpected := right
+		rexpected := left
+		if idx >= 1 && idx < 3 {
+			lexpected.Path = Path{idx + 1, 1}
+		} else if idx == 3 {
+			lexpected.Path = Path{1, 1}
+		}
+
+		validateMergeResults(t, left, right, lexpected, rexpected)
+	}
+}
+
+func TestPathChangeMergeMoveLeft(t *testing.T) {
+	initial := A{A{S("A"), S("a")}, A{S("B"), S("b")}, A{S("C"), S("c")}, A{S("D"), S("d")}, A{S("E"), S("e")}, A{S("F"), S("f")}}
+	left := changes.Move{3, 1, -2} // abcdef => adbcef
+	for idx := 0; idx < initial.Count(); idx++ {
+		before := S(("abcdef")[idx : idx+1])
+		re := changes.Replace{Before: before, After: S("boo")}
+		right := changes.PathChange{Path{idx, 1}, re}
+		lexpected := right
+		rexpected := left
+		if idx >= 1 && idx < 3 {
+			lexpected.Path = Path{idx + 1, 1}
+		} else if idx == 3 {
+			lexpected.Path = Path{1, 1}
+		}
+
+		validateMergeResults(t, left, right, lexpected, rexpected)
+	}
+}
+
+func validateMergeResults(t *testing.T, l, r, lexpected, rexpected changes.Change) {
+	validateMergeResults1(t, l, r, lexpected, rexpected)
+	validateMergeResults1(t, changes.PathChange{nil, l}, changes.PathChange{nil, r}, lexpected, rexpected)
+	validateMergeResults1(t, changes.PathChange{nil, l}, r, lexpected, rexpected)
+	validateMergeResults1(t, l, changes.PathChange{nil, r}, lexpected, rexpected)
+	lx := simplify(changes.PathChange{Path{"hello"}, lexpected})
+	rx := simplify(changes.PathChange{Path{"hello"}, rexpected})
+	left := simplify(changes.PathChange{Path{"hello"}, l})
+	right := simplify(changes.PathChange{Path{"hello"}, r})
+	validateMergeResults1(t, left, right, lx, rx)
+	validateMergeResults1(t, changes.PathChange{nil, left}, right, lx, rx)
+	validateMergeResults1(t, changes.ChangeSet{left}, right, lx, rx)
+}
+
+func validateMergeResults1(t *testing.T, l, r, lexpected, rexpected changes.Change) {
+	lx, rx := l.Merge(r)
+	if !reflect.DeepEqual(simplify(lx), lexpected) || !reflect.DeepEqual(simplify(rx), rexpected) {
+		t.Error("Unexpected l, r", lx, rx)
+	}
+
+	if r == nil {
+		return
+	}
+
+	rx, lx = r.Merge(l)
+	if !reflect.DeepEqual(simplify(lx), lexpected) || !reflect.DeepEqual(simplify(rx), rexpected) {
+		t.Error("Unexpected l, r", lx, rx)
+	}
+
+	if rev, ok := r.(revMerge); ok {
+		rx, lx := rev.ReverseMerge(l)
+		if !reflect.DeepEqual(simplify(lx), lexpected) || !reflect.DeepEqual(simplify(rx), rexpected) {
+			t.Error("Unexpected l, r", lx, rx)
+		}
+	}
+}
+
+func simplify(c changes.Change) changes.Change {
+	switch c := c.(type) {
+	case nil:
+		return nil
+	case changes.ChangeSet:
+		if len(c) == 0 {
+			return nil
+		}
+		if len(c) == 1 {
+			return simplify(c[0])
+		}
+	case changes.PathChange:
+		if cx := simplify(c.Change); cx == nil {
+			return nil
+		} else {
+			c.Change = cx
+		}
+
+		if len(c.Path) == 0 {
+			return c.Change
+		}
+
+		if pc, ok := c.Change.(changes.PathChange); ok {
+			c.Path = append([]interface{}(nil), c.Path...)
+			c.Path = append(c.Path, pc.Path...)
+			c.Change = pc.Change
+		}
+		return c
+	}
+	return c
+}
+
+type revMerge interface {
+	ReverseMerge(changes.Change) (changes.Change, changes.Change)
+}

--- a/changes/replace.go
+++ b/changes/replace.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package changes
+
+// Replace represents replacing a particular value with another
+// IsDelete is used to distinguish the case where the replace is
+// deleting a value as opposed to setting it to nil
+//
+// Before is ignored for IsInsert and After is ignored for IsDelete.
+type Replace struct {
+	IsDelete      bool  `json:",omitempty"`
+	IsInsert      bool  `json:",omitempty"`
+	Before, After Value `json:",omitempty"`
+}
+
+// Revert inverts the effect of the replace
+func (s Replace) Revert() Change {
+	return Replace{s.IsInsert, s.IsDelete, s.After, s.Before}
+}
+
+// MergeReplace merges against another Replace change.  The last writer wins
+// here with the receiver assumed to be the earlier change
+func (s Replace) MergeReplace(other Replace) (other1, s1 *Replace) {
+	if s.IsDelete && other.IsDelete {
+		return nil, nil
+	}
+
+	other.IsInsert = s.IsDelete
+	other.Before = s.After
+	return &other, nil
+}
+
+// MergeSplice merges against a Splice change.  The replace wins
+func (s Replace) MergeSplice(other Splice) (other1 *Splice, s1 *Replace) {
+	s.Before = s.Before.Apply(other)
+	return nil, &s
+}
+
+// MergeMove merges against a Move change.  The replace wins
+func (s Replace) MergeMove(other Move) (other1 *Move, s1 *Replace) {
+	s.Before = s.Before.Apply(other)
+	return nil, &s
+}
+
+// Merge implements the Change.Merge method
+func (s Replace) Merge(other Change) (otherx, cx Change) {
+	if other == nil {
+		return nil, s
+	}
+
+	switch o := other.(type) {
+	case Replace:
+		return change(s.MergeReplace(o))
+	case Splice:
+		return change(s.MergeSplice(o))
+	case Move:
+		return change(s.MergeMove(o))
+	case revMerge:
+		return swap(o.ReverseMerge(s))
+	}
+	panic("Unexpected change")
+}
+
+// Change returns either nil or a Change
+func (s *Replace) Change() Change {
+	if s == nil {
+		return nil
+	}
+	return *s
+}

--- a/changes/revert_test.go
+++ b/changes/revert_test.go
@@ -1,0 +1,47 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package changes_test
+
+import (
+	"github.com/dotchain/dot/changes"
+	"testing"
+)
+
+func TestReverts(t *testing.T) {
+	initial := S("hello")
+	cx := []changes.Change{
+		changes.Replace{Before: initial, After: S("World")},
+		changes.Replace{Before: initial, After: changes.Nil, IsDelete: true},
+		changes.Splice{1, S(""), S("OK!")},
+		changes.Splice{1, S("el"), S("")},
+		changes.Splice{1, S("el"), S("goo")},
+
+		changes.Move{1, 2, -1},
+		changes.Move{1, 2, 1},
+		changes.Move{0, 2, 1},
+	}
+	for _, c := range cx {
+		changed := initial.Apply(c).Apply(c.Revert())
+		if changed != initial {
+			t.Error("Revert failed to properly revert", c)
+		}
+		if c.Revert().Revert() != c {
+			t.Error("Revert failed to properly revert", c, c.Revert(), c.Revert().Revert())
+		}
+
+	}
+}
+
+func TestRevertsChangeSet(t *testing.T) {
+	initial := S("hello")
+	cx := changes.ChangeSet{
+		changes.Splice{0, S(""), S("OK")},
+		changes.Splice{3, S("el"), S("je")},
+	}
+	changed := initial.Apply(cx).Apply(cx.Revert())
+	if changed != initial {
+		t.Error("Unexpected revert", changed)
+	}
+}

--- a/changes/splice.go
+++ b/changes/splice.go
@@ -1,0 +1,201 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package changes
+
+// Splice represents an array edit change.  A set of elements from the
+// specified offset are removed and replaced with a new set of elements.
+type Splice struct {
+	Offset        int
+	Before, After Value `json:",omitempty"`
+}
+
+// Revert inverts the effect of the splice.
+func (s Splice) Revert() Change {
+	return Splice{s.Offset, s.After, s.Before}
+}
+
+// MergeReplace merges a move against a Replace.  The replace always wins
+func (s Splice) MergeReplace(other Replace) (other1 *Replace, s1 *Splice) {
+	other.Before = other.Before.Apply(s)
+	return &other, nil
+}
+
+// MergeSplice merges a splice against another Splice.
+func (s Splice) MergeSplice(other Splice) (other1, s1 *Splice) {
+	sstart, send := s.Offset, s.Offset+s.Before.Count()
+	ostart, oend := other.Offset, other.Offset+other.Before.Count()
+
+	switch {
+	case send <= ostart: // [  ] <  >
+		other.Offset += s.After.Count() - (send - sstart)
+		return &other, &s
+	case sstart >= oend: // < > [ ]
+		sx := s
+		sx.Offset += other.After.Count() - (oend - ostart)
+		return &other, &sx
+	case sstart < ostart && send < oend: // [  < ]  >
+		other.Offset = sstart + s.After.Count()
+		other.Before = other.Before.Slice(send-ostart, oend-send)
+
+		s.Before = s.Before.Slice(0, ostart-sstart)
+		return &other, &s
+
+	case sstart == ostart && send < oend: // [<  ]   >
+		other.Before = other.Before.Apply(Splice{0, s.Before, s.After})
+		return &other, nil
+
+	case sstart <= ostart && send >= oend: // [ < > ]
+		sliced := s.Before.Slice(ostart-sstart, oend-ostart)
+		s.Before = s.Before.Apply(Splice{ostart - sstart, sliced, other.After})
+		return nil, &s
+
+	case sstart > ostart && send <= oend: // < [ ]>
+		sliced := other.Before.Slice(sstart-ostart, send-sstart)
+		other.Before = other.Before.Apply(Splice{sstart - ostart, sliced, s.After})
+		return &other, nil
+	default: // sstart < oend: // < [ > ]
+		other.Before = other.Before.Slice(0, sstart-ostart)
+		sx := s
+		sx.Offset = ostart + other.After.Count()
+		sx.Before = s.Before.Slice(oend-sstart, send-oend)
+		return &other, &sx
+	}
+}
+
+// MergeMove merges a splice against a move
+func (s Splice) MergeMove(o Move) (ox, sx Change) {
+	beforeSize := s.Before.Count()
+	if o.Offset >= s.Offset && o.Offset+o.Count <= s.Offset+beforeSize {
+		return s.mergeContainedMove(o)
+	}
+
+	if o.Offset <= s.Offset && o.Offset+o.Count >= s.Offset+beforeSize {
+		o.Count += s.After.Count() - beforeSize
+		s.Offset += o.Distance
+		return o, s
+	}
+
+	if o.Offset >= s.Offset+beforeSize || s.Offset >= o.Offset+o.Count {
+		return s.mergeNonOverlappingMove(o)
+	}
+
+	// first undo the intersection and then merge as before
+	rest, undo := o, Move{Offset: o.Offset + o.Distance}
+	if o.Offset > s.Offset {
+		left := s.Offset + beforeSize - o.Offset
+		rest.Offset += left
+		rest.Count -= left
+		undo.Count = left
+		if o.Distance < 0 {
+			rest.Distance -= left
+			undo.Distance = o.Count - left - o.Distance
+		} else {
+			undo.Distance = -o.Distance
+		}
+	} else {
+		right := o.Offset + o.Count - s.Offset
+		rest.Count -= right
+		undo.Count = right
+		undo.Offset += rest.Count
+		if o.Distance < 0 {
+			undo.Distance = -o.Distance
+		} else {
+			rest.Distance += right
+			undo.Distance = right - o.Distance - o.Count
+		}
+	}
+
+	ox, sx = s.mergeNonOverlappingMove(rest)
+	if a, ok := sx.(ChangeSet); ok {
+		sx = ChangeSet(append([]Change{undo}, a...))
+	} else {
+		sx = ChangeSet{undo, sx}
+	}
+	return ox, sx
+}
+
+func (s Splice) mergeNonOverlappingMove(o Move) (ox, sx Change) {
+	odest, beforeSize := o.dest(), s.Before.Count()
+	diff := s.After.Count() - beforeSize
+	if odest > s.Offset && odest < s.Offset+beforeSize {
+		right := s.Offset + beforeSize - odest
+		s1 := s
+		s1.Before = s.Before.Slice(0, odest-s.Offset)
+		s2 := Splice{o.Offset + o.Count + o.Distance, Nil, Nil}
+		s2.Before = s.Before.Slice(odest-s.Offset, right)
+
+		if o.Offset < s.Offset {
+			s1.Offset -= o.Count
+			o.Distance += right + diff
+		} else {
+			o.Distance += right
+			o.Offset += diff
+		}
+		return o, ChangeSet([]Change{s2, s1})
+	}
+
+	if odest <= s.Offset {
+		if o.Offset > s.Offset {
+			o.Offset += diff
+			o.Distance -= diff
+			s.Offset += o.Count
+		}
+	} else if odest >= s.Offset+s.Before.Count() {
+		if o.Offset > s.Offset {
+			o.Offset += diff
+		} else {
+			o.Distance += diff
+			s.Offset -= o.Count
+		}
+	}
+	return o, s
+}
+
+func (s Splice) mergeContainedMove(o Move) (ox, sx Change) {
+	beforeSize, odest := s.Before.Count(), o.dest()
+	if odest >= s.Offset && odest <= s.Offset+beforeSize {
+		s.Before = s.Before.Apply(Move{o.Offset - s.Offset, o.Count, o.Distance})
+		return nil, s
+	}
+
+	sliced := s.Before.Slice(o.Offset-s.Offset, o.Count)
+	spliced := s.Before.Apply(Splice{o.Offset - s.Offset, sliced, Nil})
+
+	if odest < s.Offset {
+		ox = Splice{odest, Nil, sliced}
+		sx = Splice{s.Offset + o.Count, spliced, s.After}
+		return ox, sx
+	}
+	ox = Splice{odest + s.After.Count() - beforeSize, Nil, sliced}
+	s.Before = spliced
+	return ox, s
+}
+
+// Merge implements the Change.Merge method
+func (s Splice) Merge(other Change) (otherx, cx Change) {
+	if other == nil {
+		return nil, s
+	}
+
+	switch o := other.(type) {
+	case Replace:
+		return change(s.MergeReplace(o))
+	case Splice:
+		return change(s.MergeSplice(o))
+	case Move:
+		return s.MergeMove(o)
+	case revMerge:
+		return swap(o.ReverseMerge(s))
+	}
+	panic("Unexpected change")
+}
+
+// Change returns nil or the underlying Splice
+func (s *Splice) Change() Change {
+	if s == nil {
+		return nil
+	}
+	return *s
+}

--- a/changes/string_test.go
+++ b/changes/string_test.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package changes_test
+
+import (
+	"fmt"
+	"github.com/dotchain/dot/changes"
+)
+
+// S implements the Value interface. Note that this implementation is
+// only safe when using a byte encoding and so is not entirely
+// portable across other languages.  It is meant for test purposes
+// only.
+type S string
+
+func (s S) Slice(offset, count int) changes.Value {
+	return S(s[offset : offset+count])
+}
+
+func (s S) Count() int {
+	return len(s)
+}
+
+func (s S) toString(v changes.Value) string {
+	if v == changes.Nil {
+		return ""
+	}
+	return string(v.(S))
+}
+
+func (s S) Apply(c changes.Change) changes.Value {
+	switch c := c.(type) {
+	case nil:
+		return s
+	case changes.Replace:
+		if c.IsDelete {
+			return changes.Nil
+		}
+		return c.After
+	case changes.Splice:
+		remove := len(s.toString(c.Before))
+		after := S(s.toString(c.After))
+		return S(s[:c.Offset] + after + s[c.Offset+remove:])
+	case changes.Move:
+		ox, cx, dx := c.Offset, c.Count, c.Distance
+		if dx < 0 {
+			ox, cx, dx = ox+dx, -dx, cx
+		}
+		l, m1, m2, r := s[:ox], s[ox:ox+cx], s[ox+cx:ox+cx+dx], s[ox+cx+dx:]
+		return S(l + m2 + m1 + r)
+	case changes.ChangeSet:
+		v := changes.Value(s)
+		for _, cx := range c {
+			if cx != nil {
+				if v == nil {
+					fmt.Println("Unexpected nil v", cx)
+				}
+				v = v.Apply(cx)
+			}
+		}
+		return v
+	case changes.PathChange:
+		if len(c.Path) == 0 {
+			return s.Apply(c.Change)
+		}
+	}
+	panic(fmt.Sprintf("Unexpected Apply %#v", c))
+}

--- a/test/seqtest/seqtest.go
+++ b/test/seqtest/seqtest.go
@@ -1,0 +1,318 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+// Package seqtest contains a table of human readable sequence tests
+// and some helper methods to run tests from it.
+//
+// Each test is represented by three strings: the left change, the
+// right change and the final output.
+//
+// Each change string stores a string representation of the change.
+// Splices are represented by using square brackets to indicate
+// the region of text that is being mutated.  Within the square
+// brackets the original text before mutation is on the left of
+// the vertical | sign with the mutated value to the right.
+//
+// So, a splice operation that takes:
+//   Hello World
+// and changes it to
+//   Hello cruel world
+// would look like this
+//   Hello [W|cruel w]orld
+//
+// Insertions would basically have a blank value to the left of
+// the or | sign and deletions would have a blank value to the
+// right.
+// Moves use a similar scheme of tagging the items being moved
+// with square brackets but the location of the destination is
+// shown with the | sign.
+//
+// So, a move operation that takes:
+//   Hello bad big world!
+// and changes it to
+//   Hello big bad wrold:
+// would look something like:
+//   Hello |bad [big ]world!
+//
+//
+// Range operations are a bit more complicated to encode. A range
+// change looks like a splice except the replacement string is one of
+// the following four: "strike", "unstrike", "underline" and
+// "ununderline".  These replacements indicate the actual inner
+// operation in the range: setting or unsetting the specified
+// attributes for the range.
+
+// Package seqtest implements a standard suite of validations.
+package seqtest
+
+import (
+	"regexp"
+	"strings"
+)
+
+// StringMutator is the interface to create changes
+type StringMutator interface {
+	Splice(initial string, offset, count int, replacement string) interface{}
+	Move(initial string, offset, count, distance int) interface{}
+	Range(initial string, offset, count int, attribute string) interface{}
+}
+
+// Validator is the interface to actually implement changes
+type Validator func(name, initial string, left, right interface{}, merged string)
+
+// ForEachTest iterates through all the tests
+func ForEachTest(left, right StringMutator, validate Validator) {
+	for _, test := range sequenceTests {
+		l, initial := parse(test[0], left)
+		r, _ := parse(test[1], right)
+		
+		name := test[0] + " x " + test[1]
+		validate(name, initial, l, r, test[2])
+	}
+}
+
+var mutationRE = regexp.MustCompile(`\[.*\]`)
+var attributes = map[string]bool{
+	"strike": true,
+	"unstrike": true,
+	"underline": true,
+	"ununderline": true,
+}
+func parse(s string, m StringMutator) (interface{}, string) {
+	indices := mutationRE.FindStringIndex(s)
+	inner := s[indices[0]+1:indices[1]-1]
+	left, right := s[:indices[0]], s[indices[1]:]
+
+	if pipe := strings.IndexAny(inner, "|"); pipe >= 0 {
+		before, after := inner[:pipe], inner[pipe+1:]
+		initial := left + before + right
+		if attributes[after] {
+			return m.Range(initial, indices[0], len(before), after), initial
+		}
+		return m.Splice(initial, indices[0], len(before), after), initial
+	}
+
+	if pipe := strings.IndexAny(left, "|"); pipe >= 0 {
+		initial := left[:pipe] + left[pipe+1:] + inner + right
+		distance := len(left) - 1 - pipe
+		return m.Move(initial, len(left)-1, len(inner), -distance), initial
+	}
+
+	pipe := strings.IndexAny(right, "|")
+	initial := left + inner + right[:pipe] + right[pipe+1:]
+	return m.Move(initial, len(left), len(inner), pipe), initial
+}
+
+var sequenceTests = [][3]string{
+	// Series A: non conflicting splice splice actions
+	{"-abc[123|d]efg-", "-abc123[efg|EFG]-", "-abcdEFG-"},
+	{"-abc[123|d]efg-", "-abc123[|EFG]efg-", "-abcdEFGefg-"},
+	{"-abc[123|d]efg-", "-abc123[efg|]-", "-abcd-"},
+
+	{"-abc123[|d]efg-", "-abc123[efg|EFG]-", "-abc123dEFG-"},
+	{"-abc123[|d]efg-", "-abc123[|EFG]efg-", "-abc123dEFGefg-"},
+	{"-abc123[|d]efg-", "-abc123[efg|]-", "-abc123d-"},
+
+	{"-abc[123|]efg-", "-abc123[efg|EFG]-", "-abcEFG-"},
+	{"-abc[123|]efg-", "-abc123[|EFG]efg-", "-abcEFGefg-"},
+	{"-abc[123|]efg-", "-abc123[efg|]-", "-abc-"},
+
+	{"-abc123[efg|EFG]-", "-abc[123|d]efg-", "-abcdEFG-"},
+	{"-abc123[|EFG]efg-", "-abc[123|d]efg-", "-abcdEFGefg-"},
+	{"-abc123[efg|]-", "-abc[123|d]efg-", "-abcd-"},
+
+	// sstart = 2/2, ostart = 0/2
+
+	{"-abc123[efg|EFG]-", "-abc123[|d]efg-", "-abc123dEFG-"},
+	{"-abc123[|EFG]efg-", "-abc123[|d]efg-", "-abc123EFGdefg-"},
+	{"-abc123[efg|]-", "-abc123[|d]efg-", "-abc123d-"},
+
+	{"-abc123[efg|EFG]-", "-abc[123|]efg-", "-abcEFG-"},
+	{"-abc123[|EFG]efg-", "-abc[123|]efg-", "-abcEFGefg-"},
+	{"-abc123[efg|]-", "-abc[123|]efg-", "-abc-"},
+
+	
+	// Series A.1 - conflicting splices
+	{"-abc[123|d]4fgh-", "-abc12[34|e]fgh-", "-abcdefgh-"},
+	{"-abc[123|]4fgh-", "-abc12[34|e]fgh-", "-abcefgh-"},
+
+	{"-abc[123|d]4fgh-", "-abc[1234|e]fgh-", "-abcefgh-"},
+	{"-abc[123|]4fgh-", "-abc[1234|e]fgh-", "-abcefgh-"},
+
+	{"-abc12[34|d]fgh-", "-abc[123|e]4fgh-", "-abcedfgh-"},
+	{"-abc12[34|]fgh-", "-abc[123|e]4fgh-", "-abcefgh-"},	
+
+	{"-abc[1234|d]fgh-", "-abc12[34|e]fgh-", "-abcdfgh-"},
+	{"-abc12[34|e]fgh-", "-abc[1234|d]fgh-", "-abcdfgh-"},
+
+	{"-abc[1234|d]fgh-", "-abc[12|e]34fgh-", "-abcdfgh-"},
+	{"-abc[12|e]34fgh-", "-abc[1234|d]fgh-", "-abcdfgh-"},
+
+	{"-abc[1234|d]fgh-", "-abc1[23|e]4fgh-", "-abcdfgh-"},
+	{"-abc1[23|e]4fgh-", "-abc[1234|d]fgh-", "-abcdfgh-"},
+
+	
+	// Series B: non conflicting simple move move actions
+
+	{"-abc[123]d|e456fg-", "-abc123d|e[456]fg-", "-abcd456123efg-"}, // unexpected but ok
+
+	{"-abc[123]d|e456fg-", "-abc123d|e[456]fg-", "-abcd456123efg-"},
+	{"-abc[123]d|456efg-", "-abc123d[456]e|fg-", "-abcd123e456fg-"},
+	{"-ab|c[123]d456efg-", "-abc123|d[456]efg-", "-ab123c456defg-"},
+	{"-ab|c[123]456def-", "-abc123[456]d|ef-", "-ab123cd456ef-"},
+
+	// Series C: non conflicting move actions that span over each other
+
+	{"-abc[123]de|456fg-", "-abc123d|e[456]fg-", "-abcd456e123fg-"},
+	{"-abc[123]d|e456fg-", "-abc123|de[456]fg-", "-abc456d123efg-"},
+	{"-abc[123]de|456fg-", "-abc123|de[456]fg-", "-abc456de123fg-"},
+	{"-abc[123]de456|fg-", "-abc|123de[456]fg-", "-abc456de123fg-"},
+	{"-abc[123]de456f|g-", "-ab|c123de[456]fg-", "-ab456cdef123g-"},
+	{"-abc[123]de456f|g-", "-abc123de[456]fg|-", "-abcdef123g456-"},
+
+	// conflicting move move tests
+	{"-abc[123]de4|56fg-", "-abc1|23de[456]fg-", "-abc456de123fg-"},
+
+	// Series D: non-conflicting splice vs move
+	{"-abc[123|d]e456f-", "-abc123|e[456]f-", "-abcd456ef-"},
+	{"-abc[123|d]e456f-", "-abc123e[456]f|-", "-abcdef456-"},
+	{"-abc[123|d]e456f-", "-abc|123e[456]f-", "-abc456def-"},
+	{"-abc[123|d]e456f-", "-ab|c123e[456]f-", "-ab456cdef-"},
+	{"-abc[123|]e456f-", "-abc123|e[456]f-", "-abc456ef-"},
+	{"-abc[123|]e456f-", "-abc123e[456]f|-", "-abcef456-"},
+	{"-abc[123|]e456f-", "-abc|123e[456]f-", "-abc456ef-"},
+	{"-abc[123|]e456f-", "-ab|c123e[456]f-", "-ab456cef-"},
+	{"-abc123[|d]e456f-", "-abc123|e[456]f-", "-abc123456def-"}, // ok.  can also be abc1234d456f
+	{"-abc123[|d]e456f-", "-abc123e[456]f|-", "-abc123def456-"},
+	{"-abc123[|d]e456f-", "-abc|123e[456]f-", "-abc456123def-"},
+	{"-abc123[|d]e456f-", "-ab|c123e[456]f-", "-ab456c123def-"},
+
+	{"-abc[123|d]456f-", "-abc123[456]f|-", "-abcdf456-"},
+	{"-abc[123|d]456f-", "-abc|123[456]f-", "-abc456df-"},
+	{"-abc[123|d]456f-", "-ab|c123[456]f-", "-ab456cdf-"},
+	{"-abc[123|]456f-", "-abc123[456]f|-", "-abcf456-"},
+	{"-abc[123|]456f-", "-abc|123[456]f-", "-abc456f-"},
+	{"-abc[123|]456f-", "-ab|c123[456]f-", "-ab456cf-"},
+	{"-abc123[|d]456f-", "-abc123[456]f|-", "-abc123df456-"},
+	{"-abc123[|d]456f-", "-abc|123[456]f-", "-abc456123df-"},
+	{"-abc123[|d]456f-", "-ab|c123[456]f-", "-ab456c123df-"},
+
+	// Series E: non-conflicting move vs splice
+	{"-ab|c[123]de456gh-", "-abc123de[456|f]gh-", "-ab123cdefgh-"},
+	{"-abc[123]d|e456gh-", "-abc123de[456|f]gh-", "-abcd123efgh-"},
+	{"-abc[123]de|456gh-", "-abc123de[456|f]gh-", "-abcde123fgh-"},
+	{"-abc[123]de456|gh-", "-abc123de[456|f]gh-", "-abcdef123gh-"},
+	{"-abc[123]de456g|h-", "-abc123de[456|f]gh-", "-abcdefg123h-"},
+
+	{"-ab|c[123]de456gh-", "-abc123de[456|]gh-", "-ab123cdegh-"},
+	{"-abc[123]d|e456gh-", "-abc123de[456|]gh-", "-abcd123egh-"},
+	{"-abc[123]de|456gh-", "-abc123de[456|]gh-", "-abcde123gh-"},
+	{"-abc[123]de456|gh-", "-abc123de[456|]gh-", "-abcde123gh-"},
+	{"-abc[123]de456g|h-", "-abc123de[456|]gh-", "-abcdeg123h-"},
+
+	{"-ab|c[123]degh-", "-abc123de[|f]gh-", "-ab123cdefgh-"},
+	{"-abc[123]d|egh-", "-abc123de[|f]gh-", "-abcd123efgh-"},
+	{"-abc[123]de|gh-", "-abc123de[|f]gh-", "-abcde123fgh-"},
+	{"-abc[123]deg|h-", "-abc123de[|f]gh-", "-abcdefg123h-"},
+
+	{"-ab|c[123]456ef-", "-abc123[456|d]ef-", "-ab123cdef-"},
+	{"-abc[123]456|ef-", "-abc123[456|d]ef-", "-abcd123ef-"},
+	{"-abc[123]456e|f-", "-abc123[456|d]ef-", "-abcde123f-"},
+
+	{"-ab|c[123]456ef-", "-abc123[456|]ef-", "-ab123cef-"},
+	{"-abc[123]456|ef-", "-abc123[456|]ef-", "-abc123ef-"},
+	{"-abc[123]456e|f-", "-abc123[456|]ef-", "-abce123f-"},
+
+	{"-ab|c[123]ef-", "-abc123[|d]ef-", "-ab123cdef-"},
+	{"-abc[123]e|f-", "-abc123[|d]ef-", "-abcde123f-"},
+
+	// Series F: Splices conflicting with moves.
+	// Note a very large number of cases here are testable but the actual
+	// results of these operations are not interesting so long as there is "convergence"
+	// so the only real test being done is when one range fully contains the other.
+	{"-abc[1234|d]ef-", "-abc[12]3|4ef-", "-abcdef-"},
+	{"-abc[1234|d]ef-", "-ab|c[1234]ef-", "-abdcef-"},
+	{"-abc[1234|]ef-", "-ab|c[1234]ef-", "-abcef-"},
+	{"-abc[|d]ef-", "-a|b[ce]f-", "-acebdf-"}, // this is odd but ok
+	{"-abc[|d]ef-", "-ab|c[]ef-", "-abcdef-"},
+	{"-ab|c[1234]ef-", "-abc1[23|d]4ef-", "-ab1d4cef-"},
+
+	// Range tests are a bit more involved.
+	// 1. Each string is considered as an array (since range operations require elements to
+	//    apply changes to)
+	// 2. Each array is of the form of a set of three fields: char, strike and underline
+	// 3. Char holds the byte code of the character. The other two hold formatting info.
+	// 4. Range operations look like splice in the examples here but the replacement text
+	//    is one of "strike", "unstrike", "underline", "ununderline".  These get translated
+	//    to a range operation that uses the corresponding set mutation on all the elements
+	// 5. Textual representation of strike through and underline is done via unicode.
+	//    Use "go run cmd/underline/underline.go brick" to get the formatted version of "brick"
+	// 6. The code has a sloppy way of detecting if the input is meant to be a regular splice or a
+	//    range version.  It does this by detecting if any of the strings have strike through or
+	//    underline formatting.  So, range tests sometimes have an artificial strike through in
+	//    the leading character to trigger this.
+
+	// Note that VI edits these characters very well.  Emacs is not quite as nice.
+
+	// Range/Splice no conflict
+	{"-yellow [brick|strike] road-", "-[yellow|YELLOW] brick road-", "-YELLOW b̶r̶i̶c̶k̶ road-"},
+	{"-yellow [brick|strike] road-", "-[yellow |YELLOW ]brick road-", "-YELLOW b̶r̶i̶c̶k̶ road-"},
+	{"-yellow [brick|strike] road-", "-yellow brick[ road| ROAD]-", "-yellow b̶r̶i̶c̶k̶ ROAD-"},
+	{"-yellow [brick|strike] road-", "-yellow brick [road|ROAD]-", "-yellow b̶r̶i̶c̶k̶ ROAD-"},
+
+	// Range covers splice
+	{"-yellow [brick|strike] road-", "-yellow [bri|BRI]ck road-", "-yellow B̶R̶I̶c̶k̶ road-"},
+	{"-yellow [brick|strike] road-", "-yellow b[ric|RIC]k road-", "-yellow b̶R̶I̶C̶k̶ road-"},
+	{"-yellow [brick|strike] road-", "-yellow br[ick|ICK] road-", "-yellow b̶r̶I̶C̶K̶ road-"},
+
+	// splice covers range.  Note that the first character in these has a strike through
+	// to force going through the formatted parsing code
+	{"-S̶yellow [brick|strike] road-", "-S̶[yellow brick road|YELLOW BRICK ROAD]-", "-S̶YELLOW BRICK ROAD-"},
+	{"-S̶yellow [brick|strike] road-", "-S̶yellow [brick road|BRICK ROAD]-", "-S̶yellow BRICK ROAD-"},
+	{"-S̶yellow [brick|strike] road-", "-S̶yellow [brick|BRICK] road-", "-S̶yellow BRICK road-"},
+	{"-S̶yellow [brick|strike] road-", "-S̶[yellow brick|YELLOW BRICK] road-", "-S̶YELLOW BRICK road-"},
+
+	// Range intersects splice
+	{"-yellow [brick|strike] road-", "-yello[w br|W BR]ick road-", "-yelloW BRi̶c̶k̶ road-"},
+	{"-yellow [brick|strike] road-", "-yellow br[ick r|ICK R]oad-", "-yellow b̶r̶ICK Road-"},
+
+	// Range/Range tests
+	{"-yellow [brick|strike] road-", "-yellow [brick|underline] road-", "-yellow b̶͟r̶͟i̶͟c̶͟k̶͟ road-"},
+	{"-[yellow|strike] brick road-", "-yellow brick [road|underline]-", "-y̶e̶l̶l̶o̶w̶ brick r͟o͟a͟d͟-"},
+	{"-yellow [bric|strike]k road-", "-yellow b[rick|underline] road-", "-yellow b̶r̶͟i̶͟c̶͟k͟ road-"},
+	{"-yellow [brick|strike] road-", "-yellow b[ric|underline]k road-", "-yellow b̶r̶͟i̶͟c̶͟k̶ road-"},
+
+	// Range/Move tests
+	// No conflicts
+	{"-yellow [brick|strike] road-", "-[yellow] |brick road-", "- yellowb̶r̶i̶c̶k̶ road-"},
+	{"-yellow [brick|strike] road-", "|-[yellow ]brick road-", "yellow -b̶r̶i̶c̶k̶ road-"},
+	{"-yellow [brick|strike] road-", "-[yellow] brick| road-", "- b̶r̶i̶c̶k̶yellow road-"},
+	{"-yellow [brick|strike] road-", "-yellow brick| [road]-", "-yellow b̶r̶i̶c̶k̶road -"},
+	{"-yellow [brick|strike] road-", "-yellow brick[ road]-|", "-yellow b̶r̶i̶c̶k̶- road"},
+	{"-yellow [brick|strike] road-", "-yellow |brick[ road]-", "-yellow  roadb̶r̶i̶c̶k̶-"},
+
+	// No conflicts but insertion
+	{"-yellow [brick|strike] road-", "-[yellow] br|ick road-", "- b̶r̶yellowi̶c̶k̶ road-"},
+	{"-yellow [brick|strike] road-", "-[yellow ]br|ick road-", "-b̶r̶yellow i̶c̶k̶ road-"},
+	{"-yellow [brick|strike] road-", "-yellow br|ick[ road]-", "-yellow b̶r̶ roadi̶c̶k̶-"},
+	{"-yellow [brick|strike] road-", "-yellow br|ick [road]-", "-yellow b̶r̶roadi̶c̶k̶ -"},
+
+	// Move covers range
+	{"-yellow [brick|strike] road-", "-yellow[ brick] |road-", "-yellow  b̶r̶i̶c̶k̶road-"},
+	{"-yellow [brick|strike] road-", "-yellow| [brick ]road-", "-yellowb̶r̶i̶c̶k̶  road-"},
+	{"-yellow [brick|strike] road-", "-|yellow[ brick ]road-", "- b̶r̶i̶c̶k̶ yellowroad-"},
+
+	// Range covers move
+	{"-yellow [brick|strike] road-", "-yellow b|r[ick] road-", "-yellow b̶i̶c̶k̶r̶ road-"},
+	{"-yellow [brick|strike] road-", "-yellow| [b]rick road-", "-yellowb̶ r̶i̶c̶k̶ road-"},
+	{"-yellow [brick|strike] road-", "-yellow| [brick] road-", "-yellowb̶r̶i̶c̶k̶  road-"},
+
+	// Range intersects move
+	{"-yellow [brick|strike] road-", "-yellow b|r[ick ]road-", "-yellow b̶i̶c̶k̶ r̶road-"},
+	{"-yellow [brick|strike] road-", "-yellow| br[ick ]road-", "-yellowi̶c̶k̶  b̶r̶road-"},
+	{"-yellow [brick|strike] road-", "-yellow br[ick ]road|-", "-yellow b̶r̶roadi̶c̶k̶ -"},
+	{"-yellow [brick|strike] road-", "-yellow[ b]r|ick road-", "-yellowr̶ b̶i̶c̶k̶ road-"},
+	{"-yellow [brick|strike] road-", "-yellow[ b]rick |road-", "-yellowr̶i̶c̶k̶  b̶road-"},
+	{"-yellow [brick|strike] road-", "-|yellow[ b]rick road-", "- b̶yellowr̶i̶c̶k̶ road-"},
+}

--- a/x/rt/array_test.go
+++ b/x/rt/array_test.go
@@ -1,0 +1,83 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package rt_test
+
+import (
+	"fmt"
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/x/rt"
+)
+
+// A implements the Value interface over a slice of values
+type A []changes.Value
+
+func (a A) Slice(offset, count int) changes.Value {
+	return a[offset : offset+count]
+}
+
+func (a A) Count() int {
+	return len(a)
+}
+
+func (a A) move(ox, cx, dx int) changes.Value {
+	if dx < 0 {
+		ox, cx, dx = ox+dx, -dx, cx
+	}
+	l, m1, m2, r := a[:ox:ox], a[ox:ox+cx], a[ox+cx:ox+cx+dx], a[ox+cx+dx:]
+	return A(append(append(append(l, m2...), m1...), r...))
+}
+
+func (a A) applyChangeSet(c changes.ChangeSet) changes.Value {
+	v := changes.Value(a)
+	for _, cx := range c {
+		if cx != nil {
+			if v == nil {
+				fmt.Println("Unexpected nil v", cx)
+			}
+			v = v.Apply(cx)
+		}
+	}
+	return v
+}
+
+func (a A) run(offset, count int, c changes.Change) changes.Value {
+	copy := append([]changes.Value(nil), a...)
+	for kk := offset; kk < offset+count; kk++ {
+		copy[kk] = copy[kk].Apply(c)
+	}
+	return A(copy)
+}
+
+func (a A) Apply(c changes.Change) changes.Value {
+	switch c := c.(type) {
+	case nil:
+		return a
+	case changes.Replace:
+		if c.IsDelete {
+			return changes.Nil
+		}
+		return c.After
+	case changes.Splice:
+		after := c.After.(A)
+		result := append(a[:c.Offset:c.Offset], after...)
+		return A(append(result, a[c.Offset+c.Before.Count():]...))
+	case changes.Move:
+		return a.move(c.Offset, c.Count, c.Distance)
+	case rt.Run:
+		return a.run(c.Offset, c.Count, c.Change)
+	case changes.ChangeSet:
+		return a.applyChangeSet(c)
+	case changes.PathChange:
+		if len(c.Path) == 0 {
+			return a.Apply(c.Change)
+		}
+		idx := c.Path[0].(int)
+		clone := append([]changes.Value(nil), a...)
+		clone[idx] = clone[idx].Apply(changes.PathChange{c.Path[1:], c.Change})
+		return A(clone)
+	default:
+		panic(fmt.Sprintf("Unexpected Apply %#v", c))
+	}
+}

--- a/x/rt/rt.go
+++ b/x/rt/rt.go
@@ -1,0 +1,8 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+// Package rt implements a rich type value which supports formatting,
+// styles, lists etc
+package rt
+

--- a/x/rt/run.go
+++ b/x/rt/run.go
@@ -1,0 +1,194 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package rt
+
+import "github.com/dotchain/dot/changes"
+
+// Run implements a custom change type which applies a provided
+// inner change to a range of items in an array.  This is particularly
+// useful for rich text operations
+type Run struct {
+	Offset, Count int
+	changes.Change
+}
+
+// Revert undoes the effect of the Run
+func (r Run) Revert() changes.Change {
+	if r.Change == nil {
+		return nil
+	}
+	return Run{r.Offset, r.Count, r.Change.Revert()}
+}
+
+// Merge implements the main merge routing for a change
+func (r Run) Merge(o changes.Change) (changes.Change, changes.Change) {
+	return r.merge(o, false)
+}
+
+// ReverseMerge is like Merge except the args and receiver are
+// inverted. Basically if someone calls "ch.Merge(r)" and ch does not
+// know how to implement merge with r, it calls r.ReverseMerge(ch).
+func (r Run) ReverseMerge(o changes.Change) (changes.Change, changes.Change) {
+	return r.merge(o, true)
+}
+
+func (r Run) merge(o changes.Change, reverse bool) (changes.Change, changes.Change) {
+	if r.Change == nil {
+		return o, nil
+	}
+
+	switch o := o.(type) {
+	case nil:
+		return nil, r
+	case changes.Replace:
+		o.Before = o.Before.Apply(r)
+		return o, nil
+	case changes.Splice:
+		return r.mergeSplice(o)
+	case changes.Move:
+		return r.mergeMove(o)
+	case Run:
+		return r.mergeRun(o, reverse)
+	case changes.PathChange:
+		return r.mergePathChange(o, reverse)
+	}
+
+	if reverse {
+		return swap(o.Merge(r))
+	}
+	return swap(o.(revMerge).ReverseMerge(r))
+}
+
+func (r Run) mergeSplice(o changes.Splice) (changes.Change, changes.Change) {
+	oEnd := o.Offset + o.Before.Count()
+	switch {
+	case r.Offset >= oEnd:
+		r.Offset += o.After.Count() - o.Before.Count()
+	case r.Offset+r.Count <= o.Offset:
+	case r.Offset >= o.Offset && r.Offset+r.Count <= oEnd:
+		r.Offset -= o.Offset
+		o.Before = o.Before.Apply(r)
+		return o, nil
+	case r.Offset <= o.Offset && r.Offset+r.Count >= oEnd:
+		o.Before = o.Before.Apply(Run{0, o.Before.Count(), r.Change})
+		left := Run{r.Offset, o.Offset - r.Offset, r.Change}
+		right := Run{o.Offset + o.After.Count(), r.Offset + r.Count - oEnd, r.Change}
+		return o, changes.ChangeSet{left, right}
+	case r.Offset < o.Offset && o.Offset < r.Offset+r.Count:
+		o.Before = o.Before.Apply(Run{0, r.Offset + r.Count - o.Offset, r.Change})
+		r.Count = o.Offset - r.Offset
+	case r.Offset > o.Offset && r.Offset < oEnd:
+		o.Before = o.Before.Apply(Run{r.Offset - o.Offset, oEnd - r.Offset, r.Change})
+		r.Count = r.Offset + r.Count - oEnd
+		r.Offset = o.Offset + o.After.Count()
+	}
+	return o, r
+}
+
+func (r Run) mergeMove(o changes.Move) (changes.Change, changes.Change) {
+	rEnd, oEnd := r.Offset+r.Count, o.Offset+o.Count
+	oDest := oEnd + o.Distance
+	if o.Distance < 0 {
+		oDest = o.Offset + o.Distance
+	}
+	switch {
+	case rEnd <= o.Offset && rEnd <= oDest:
+	case r.Offset >= oDest && rEnd <= o.Offset:
+		r.Offset += o.Count
+	case r.Offset >= o.Offset && rEnd <= oEnd:
+		r.Offset += o.Distance
+	case r.Offset >= oEnd && rEnd <= oDest:
+		r.Offset -= o.Count
+	case r.Offset >= oEnd && rEnd >= oDest:
+	default:
+		return r.split3(oDest, o)
+	}
+	return o, r
+}
+
+func (r Run) mergeRun(o Run, reverse bool) (changes.Change, changes.Change) {
+	rEnd, oEnd := r.Offset+r.Count, o.Offset+o.Count
+	switch {
+	case rEnd <= o.Offset || oEnd <= r.Offset:
+		return o, r
+	case r.Offset == o.Offset && rEnd == oEnd:
+		var ox, rx changes.Change
+		if reverse && o.Change != nil {
+			rx, ox = o.Change.Merge(r.Change)
+		} else {
+			ox, rx = r.Change.Merge(o.Change)
+		}
+		return Run{o.Offset, o.Count, ox}, Run{r.Offset, r.Count, rx}
+	}
+	left := r.splitRuns([]changes.Change{r}, o.Offset)
+	left = r.splitRuns(left, o.Offset+o.Count)
+	right := r.splitRuns([]changes.Change{o}, r.Offset)
+	right = r.splitRuns(right, r.Offset+r.Count)
+	lx := changes.ChangeSet(left)
+	rx := changes.ChangeSet(right)
+
+	if reverse {
+		x, y := rx.Merge(lx)
+		return y, x
+	}
+	return lx.Merge(rx)
+}
+
+func (r Run) mergePathChange(o changes.PathChange, reverse bool) (changes.Change, changes.Change) {
+	if len(o.Path) == 0 {
+		return r.merge(o.Change, reverse)
+	}
+	idx := o.Path[0].(int)
+	if idx < r.Offset || idx >= r.Offset+r.Count {
+		return o, r
+	}
+	var left, right changes.Change
+	if idx > r.Offset {
+		left = Run{r.Offset, idx - r.Offset, r.Change}
+	}
+	if idx+1 < r.Offset+r.Count {
+		right = Run{idx + 1, r.Offset + r.Count - idx - 1, r.Change}
+	}
+	other := changes.PathChange{o.Path[1:], o.Change}
+	var ox, mid changes.Change
+	if reverse {
+		mid, ox = other.Merge(r.Change)
+	} else {
+		ox, mid = r.Change.Merge(other)
+	}
+	ox = changes.PathChange{o.Path[:1], ox}
+	mid = changes.PathChange{o.Path[:1], mid}
+	return ox, changes.ChangeSet{left, mid, right}
+}
+
+func (r Run) splitRuns(runs []changes.Change, idx int) []changes.Change {
+	result := make([]changes.Change, 0, len(runs)+1)
+	for _, rx := range runs {
+		run := rx.(Run)
+		if idx > run.Offset && idx < run.Offset+run.Count {
+			left := Run{run.Offset, idx - run.Offset, run.Change}
+			right := Run{idx, run.Count + run.Offset - idx, run.Change}
+			result = append(result, left, right)
+		} else {
+			result = append(result, run)
+		}
+	}
+	return result
+}
+
+func (r Run) split3(dest int, o changes.Move) (changes.Change, changes.Change) {
+	c := r.splitRuns([]changes.Change{r}, dest)
+	c = r.splitRuns(c, o.Offset)
+	c = r.splitRuns(c, o.Offset+o.Count)
+	return changes.ChangeSet(c).Merge(o)
+}
+
+type revMerge interface {
+	ReverseMerge(changes.Change) (changes.Change, changes.Change)
+}
+
+func swap(x, y changes.Change) (xx, yy changes.Change) {
+	return y, x
+}

--- a/x/rt/run_test.go
+++ b/x/rt/run_test.go
@@ -1,0 +1,207 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package rt_test
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/x/rt"
+	"reflect"
+	"testing"
+)
+
+func TestRunRevert(t *testing.T) {
+	r := rt.Run{0, 5, nil}
+	if r.Revert() != nil {
+		t.Error("Unexpected revert", r.Revert())
+	}
+
+	r = rt.Run{0, 5, changes.Move{1, 2, 2}}
+	expected := rt.Run{0, 5, r.Change.Revert()}
+	if r.Revert() != expected {
+		t.Error("Unexpected revert", r.Revert())
+	}
+}
+
+func TestRunMergeNils(t *testing.T) {
+	r := rt.Run{0, 5, changes.Move{5, 5, 1}}
+	ox, rx := r.Merge(nil)
+	if ox != nil || rx != r {
+		t.Error("Unexpected merge", ox, rx)
+	}
+
+	ox, rx = r.ReverseMerge(nil)
+	if ox != nil || rx != r {
+		t.Error("Unexpected merge", ox, rx)
+	}
+
+	r.Change = nil
+	ox, rx = r.Merge(changes.Move{5, 5, 1})
+	if ox != (changes.Move{5, 5, 1}) || rx != nil {
+		t.Error("Unexpected merge", ox, rx)
+	}
+
+	ox, rx = r.ReverseMerge(changes.Move{5, 5, 1})
+	if ox != (changes.Move{5, 5, 1}) || rx != nil {
+		t.Error("Unexpected merge", ox, rx)
+	}
+}
+
+var first = A{S("a"), S("b")}
+var second = A{S("c"), S("d")}
+var third = A{S("e"), S("f")}
+var initial = A{first, second, third}
+
+func TestRunMergeReplace(t *testing.T) {
+	l := rt.Run{0, 2, changes.Move{0, 1, 1}}
+	r := changes.Replace{Before: initial, After: S("OK")}
+	validateMerge(t, l, r)
+	validateMerge(t, l, changes.Replace{Before: initial, After: changes.Nil, IsDelete: true})
+}
+
+func TestRunMergeSplice(t *testing.T) {
+	l := rt.Run{1, 1, changes.Move{0, 1, 1}}
+	r := changes.Splice{Offset: 0, Before: A{}, After: A{S("OK")}}
+	validateMerge(t, l, r)
+	r = changes.Splice{Offset: 0, Before: A{first}, After: A{}}
+	validateMerge(t, l, r)
+	r = changes.Splice{Offset: 2, Before: A{}, After: A{S("OK")}}
+	validateMerge(t, l, r)
+	r = changes.Splice{Offset: 1, Before: A{second}, After: A{S("OK")}}
+	validateMerge(t, l, r)
+	r = changes.Splice{Offset: 0, Before: initial, After: A{S("OK")}}
+	validateMerge(t, l, r)
+
+	l = rt.Run{0, 2, changes.Move{0, 1, 1}}
+	r = changes.Splice{1, A{second, third}, A{S("OK")}}
+	validateMerge(t, l, r)
+	l = rt.Run{1, 2, changes.Move{0, 1, 1}}
+	r = changes.Splice{0, A{first, second}, A{S("OK")}}
+	validateMerge(t, l, r)
+
+	l = rt.Run{0, 3, changes.Move{0, 1, 1}}
+	r = changes.Splice{1, A{second}, A{S("OK")}}
+	validateMerge(t, l, r)
+}
+
+func TestRunMergeMove(t *testing.T) {
+	for count := 1; count < 3; count++ {
+		for offset := 0; offset <= 3-count; offset++ {
+			for dest := 0; dest <= 3; dest++ {
+				if dest >= offset && dest <= offset+count {
+					continue
+				}
+				r := changes.Move{offset, count, dest - offset - count}
+				if dest < offset {
+					r.Distance = dest - offset
+				}
+				l := rt.Run{1, 1, changes.Move{0, 1, 1}}
+				validateMerge(t, l, r)
+				l = rt.Run{0, 2, changes.Move{0, 1, 1}}
+				validateMerge(t, l, r)
+				l = rt.Run{0, 3, changes.Move{0, 1, 1}}
+				validateMerge(t, l, r)
+			}
+		}
+	}
+}
+
+func TestRunMergeRun(t *testing.T) {
+	ForEachRun(changes.Splice{0, A{}, A{S("Left")}}, func(l rt.Run) {
+		ForEachRun(changes.Splice{0, A{}, A{S("Right")}}, func(r rt.Run) {
+			validateMerge(t, l, r)
+		})
+	})
+}
+
+func TestRunMergePathChange(t *testing.T) {
+	l := rt.Run{1, 1, changes.Splice{0, A{}, A{S("Left")}}}
+	r := changes.PathChange{nil, changes.Replace{IsDelete: true, Before: initial, After: changes.Nil}}
+	validateMerge(t, l, r)
+
+	l = rt.Run{1, 2, changes.Splice{0, A{}, A{S("Left")}}}
+	for kk := 0; kk < 3; kk++ {
+		replace := changes.Replace{IsDelete: true, Before: initial[kk], After: changes.Nil}
+		r := changes.PathChange{[]interface{}{kk}, replace}
+		validateMerge(t, l, r)
+		validateMerge(t, r, l)
+	}
+}
+
+func ForEachRun(change changes.Change, fn func(r rt.Run)) {
+	for count := 1; count <= 3; count++ {
+		for offset := 0; offset <= 3-count; offset++ {
+			fn(rt.Run{offset, count, change})
+		}
+	}
+}
+
+func validateMerge(t *testing.T, l, r changes.Change) {
+	validateMerge1(t, initial, l, r)
+	validateMerge1(t, initial, l, changes.PathChange{nil, r})
+	validateMerge1(t, initial, changes.PathChange{nil, l}, r)
+	validateMerge1(t, initial, changes.ChangeSet{l}, r)
+	validateMerge1(t, initial, l, changes.ChangeSet{r})
+}
+
+func validateMerge1(t *testing.T, initial changes.Value, l, r changes.Change) {
+	lx, rx := l.Merge(r)
+	lval := initial.Apply(l).Apply(lx)
+	rval := initial.Apply(r).Apply(rx)
+	if !reflect.DeepEqual(lval, rval) {
+		t.Error("merge failed", lval, rval, "---", l, "---", r)
+	}
+	if rev, ok := r.(revMerge); ok {
+		rx2, lx2 := rev.ReverseMerge(l)
+		lx, rx, lx2, rx2 = simplify(lx), simplify(rx), simplify(lx2), simplify(rx2)
+		if !reflect.DeepEqual(rx, rx2) || !reflect.DeepEqual(lx, lx2) {
+			t.Error("reverse merge diverged from merge", lx, lx2, rx, rx2)
+		}
+	}
+	if rev, ok := l.(revMerge); ok {
+		lx, rx = rev.ReverseMerge(r)
+		rx2, lx2 := r.Merge(l)
+
+		lx, rx, lx2, rx2 = simplify(lx), simplify(rx), simplify(lx2), simplify(rx2)
+		if !reflect.DeepEqual(rx, rx2) || !reflect.DeepEqual(lx, lx2) {
+			t.Error("reverse merge diverged from merge", lx, lx2, rx, rx2)
+		}
+	}
+}
+
+type revMerge interface {
+	ReverseMerge(changes.Change) (changes.Change, changes.Change)
+}
+
+func simplify(c changes.Change) changes.Change {
+	switch c := c.(type) {
+	case nil:
+		return nil
+	case changes.ChangeSet:
+		if len(c) == 0 {
+			return nil
+		}
+		if len(c) == 1 {
+			return simplify(c[0])
+		}
+	case changes.PathChange:
+		if cx := simplify(c.Change); cx == nil {
+			return nil
+		} else {
+			c.Change = cx
+		}
+
+		if len(c.Path) == 0 {
+			return c.Change
+		}
+
+		if pc, ok := c.Change.(changes.PathChange); ok {
+			c.Path = append([]interface{}(nil), c.Path...)
+			c.Path = append(c.Path, pc.Path...)
+			c.Change = pc.Change
+		}
+		return c
+	}
+	return c
+}

--- a/x/rt/string_test.go
+++ b/x/rt/string_test.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package rt_test
+
+import (
+	"fmt"
+	"github.com/dotchain/dot/changes"
+)
+
+// S implements the Value interface. Note that this implementation is
+// only safe when using a byte encoding and so is not entirely
+// portable across other languages.  It is meant for test purposes
+// only.
+type S string
+
+func (s S) Slice(offset, count int) changes.Value {
+	return S(s[offset : offset+count])
+}
+
+func (s S) Count() int {
+	return len(s)
+}
+
+func (s S) toString(v changes.Value) string {
+	if v == changes.Nil {
+		return ""
+	}
+	return string(v.(S))
+}
+
+func (s S) Apply(c changes.Change) changes.Value {
+	switch c := c.(type) {
+	case nil:
+		return s
+	case changes.Replace:
+		if c.IsDelete {
+			return changes.Nil
+		}
+		return c.After
+	case changes.Splice:
+		remove := len(s.toString(c.Before))
+		after := S(s.toString(c.After))
+		return S(s[:c.Offset] + after + s[c.Offset+remove:])
+	case changes.Move:
+		ox, cx, dx := c.Offset, c.Count, c.Distance
+		if dx < 0 {
+			ox, cx, dx = ox+dx, -dx, cx
+		}
+		l, m1, m2, r := s[:ox], s[ox:ox+cx], s[ox+cx:ox+cx+dx], s[ox+cx+dx:]
+		return S(l + m2 + m1 + r)
+	case changes.ChangeSet:
+		v := changes.Value(s)
+		for _, cx := range c {
+			if cx != nil {
+				if v == nil {
+					fmt.Println("Unexpected nil v", cx)
+				}
+				v = v.Apply(cx)
+			}
+		}
+		return v
+	case changes.PathChange:
+		if len(c.Path) == 0 {
+			return s.Apply(c.Change)
+		}
+	}
+	panic(fmt.Sprintf("Unexpected Apply %#v", c))
+}


### PR DESCRIPTION
This is the beginning of a bigger refactor of the dot/ project.

1. Core changes are Replace, Splice and Move.  Replace has explicit insert/delete/update separation.
2. Custom changes are possible due to the use of a simple "Change" interface
3. Before/After values are required to be concrete
4. Range operations are part of the x/ setup rather than being included by default. 
5. Range operations do not have ambiguity unlike before
6. ChangeSet and PathChange allow composition via cleaner semantics.  Path is no longer an array of strings -- collections can be indexed by numbers in a more natural fashion.  Serialization concerns are removed out of the core interfaces.
