### PR TITLE
Add refs.Container and refs.Update

### DIFF
--- a/refs/container.go
+++ b/refs/container.go
@@ -1,0 +1,97 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package refs
+
+import "github.com/dotchain/dot/changes"
+
+// Container wraps a Value and a set of references into the value.
+//
+// It implements the changes.Value interface. It acts like a
+// "map-like" object with the wrapped value taking up the key
+// "Value".  The references are not accessed vai PathChange. Instead
+// they are accessed via Update changes only. This allows
+// all changes to be properly merged.
+type Container struct {
+	changes.Value
+	refs map[interface{}]Ref
+}
+
+// UpdateRef updates a ref. If r is nil, the reference is deleted.
+// All references should have "Value" as a prefix to the path.
+func (con Container) UpdateRef(key interface{}, r Ref) (Container, changes.Change) {
+	old := con.refs[key]
+	if old == nil && r == nil {
+		return con, nil
+	}
+	c := Update{key, old, r}
+	return con.Apply(c).(Container), c
+}
+
+// GetRef returns the current ref for the provided key
+func (con Container) GetRef(key interface{}) Ref {
+	return con.refs[key]
+}
+
+// Apply implements changes.Value:Apply
+func (con Container) Apply(c changes.Change) changes.Value {
+	switch c := c.(type) {
+	case nil:
+		return con
+	case changes.Replace:
+		if !c.IsCreate() {
+			return c.After
+		}
+	case Update:
+		refs := map[interface{}]Ref{}
+		for k, v := range con.refs {
+			if k != c.Key {
+				refs[k] = v
+			}
+		}
+		if c.After != nil {
+			refs[c.Key] = c.After
+		}
+		if len(refs) == 0 {
+			refs = nil
+		}
+		return Container{con.Value, refs}
+	case changes.PathChange:
+		if len(c.Path) == 0 {
+			return con.Apply(c.Change)
+		}
+		return con.applyPathChange(c)
+	case changes.Custom:
+		return c.ApplyTo(con)
+	}
+	panic("Unknown change type")
+}
+
+func (con Container) applyPathChange(c changes.PathChange) changes.Value {
+	updated := map[interface{}]Ref{}
+	for k, ref := range con.refs {
+		ref, _ = ref.Merge(c)
+		if ref != InvalidRef {
+			updated[k] = ref
+		}
+	}
+	if len(updated) == 0 {
+		updated = nil
+	}
+	if c.Path[0] != "Value" {
+		panic("Unexpected path")
+	}
+	val := con.Value.Apply(changes.PathChange{c.Path[1:], c.Change})
+	return Container{val, updated}
+}
+
+// Slice implements changes.Value:Slice
+func (con Container) Slice(offset, count int) changes.Value {
+	panic("refs.Container does not implement Slice")
+}
+
+// Count implements changes.Value:Count
+func (con Container) Count() int {
+	panic("refs.Container does not implement Count")
+}

--- a/refs/container_test.go
+++ b/refs/container_test.go
@@ -1,0 +1,217 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package refs_test
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/refs"
+	"github.com/dotchain/dot/x/types"
+	"reflect"
+	"testing"
+)
+
+func TestUpdateMerge(t *testing.T) {
+	initial := refs.Container{
+		Value: types.M{
+			"ok":    changes.Nil,
+			"bok":   changes.Nil,
+			"loki":  changes.Nil,
+			"array": types.A{changes.Nil, changes.Nil, changes.Nil, changes.Nil, changes.Nil},
+		},
+	}
+	initial, _ = initial.UpdateRef("goo", refs.Path{"Value", "ok"})
+	initial, _ = initial.UpdateRef("array", refs.Path{"Value", "array", 1})
+
+	pairs := [][2]changes.Change{
+		{
+			refs.Update{"goo", refs.Path{"Value", "ok"}, refs.Path{"Value", "array"}},
+			nil,
+		},
+		{
+			refs.Update{"array", refs.Path{"Value", "array", 1}, refs.Path{"Value", "array"}},
+			changes.PathChange{refs.Path{"Value"}, changes.Replace{initial.Value, types.S8("ok")}},
+		},
+		{
+			refs.Update{"goo", refs.Path{"Value", "ok"}, refs.Path{"Value", "bok"}},
+			refs.Update{"goo", refs.Path{"Value", "ok"}, refs.Path{"Value", "loki"}},
+		},
+		{
+			refs.Update{"goo", refs.Path{"Value", "ok"}, refs.Path{"Value", "bok"}},
+			refs.Update{"goo", refs.Path{"Value", "ok"}, nil},
+		},
+		{
+			refs.Update{"goop", nil, refs.Path{"Value", "bok"}},
+			refs.Update{"goop", nil, refs.Path{"Value", "loki"}},
+		},
+		{
+			refs.Update{"gool", nil, refs.Path{"Value", "bok"}},
+			refs.Update{"good", nil, refs.Path{"Value", "loki"}},
+		},
+		{
+			refs.Update{"gool", nil, refs.Path{"Value", "bok"}},
+			changes.Replace{initial, types.S8("hello")},
+		},
+		{
+			refs.Update{"gool", nil, refs.Path{"Value", "array", 5}},
+			changes.PathChange{refs.Path{"Value", "array"}, changes.Move{0, 4, 1}},
+		},
+		{
+			refs.Update{"gool", nil, refs.Path{"Value", "array", 5}},
+			changes.PathChange{refs.Path{"Value", "array"}, changes.Move{0, 4, 1}},
+		},
+	}
+
+	for _, pair := range pairs {
+		c1, c2 := pair[0], pair[1]
+		c1x, c2x := c1.Merge(c2)
+		final1 := initial.Apply(c1).Apply(c1x)
+		final2 := initial.Apply(c2).Apply(c2x)
+		if !reflect.DeepEqual(final1, final2) {
+			t.Error("Failed to merge", pair)
+		}
+
+		c1y, c2y := c1.Merge(changes.PathChange{nil, changes.ChangeSet{c2}})
+		final1y := initial.Apply(c1).Apply(c1y)
+		final2y := initial.Apply(c2).Apply(c2y)
+		if !reflect.DeepEqual(final1y, final2y) || !reflect.DeepEqual(final1, final1y) {
+			t.Error("Failed to merge", pair)
+		}
+
+		if custom, ok := c1.(changes.Custom); ok {
+			c1z, c2z := custom.ReverseMerge(changes.PathChange{nil, changes.ChangeSet{c2}})
+			final1z := initial.Apply(c1).Apply(c1z)
+			final2z := initial.Apply(c2).Apply(c2z)
+			if !reflect.DeepEqual(final1z, final2z) {
+				t.Error("Failed to merge", pair)
+			}
+		}
+
+		if custom, ok := c2.(changes.Custom); ok {
+			c2x, c1x = custom.ReverseMerge(c1)
+			final1 = initial.Apply(c1).Apply(c1x)
+			final2 = initial.Apply(c2).Apply(c2x)
+			if !reflect.DeepEqual(final1, final2) {
+				t.Error("Failed to reverse merge", pair)
+			}
+		}
+	}
+}
+
+func TestUpdateUnknownMerge(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Failed to panic")
+		}
+	}()
+	u := refs.Update{"goo", refs.Path{"ok"}, refs.Path{"q"}}
+	u.Merge(changes.Move{5, 2, 2})
+}
+
+func TestUpdateMiscReverseMerge(t *testing.T) {
+	u := refs.Update{"goo", refs.Path{"ok"}, refs.Path{"q"}}
+	x, y := u.ReverseMerge(nil)
+	if !reflect.DeepEqual(y, u) || x != nil {
+		t.Error("nil reverse merge failed", x, y)
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Failed to panic")
+		}
+	}()
+	u.ReverseMerge(changes.Move{5, 2, 2})
+}
+
+func TestUpdateApplyTo(t *testing.T) {
+	initial := refs.Container{Value: types.S8("")}
+	u := refs.Update{"goo", nil, refs.Caret{refs.Path{"Value"}, 5, false}}
+	updated := initial.Apply(u)
+	alt := u.ApplyTo(initial)
+	if !reflect.DeepEqual(updated, alt) {
+		t.Error("Unexpected ApplyTo", updated, alt)
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Failed to panic")
+		}
+	}()
+	u = refs.Update{"goo", refs.Path{"ok"}, refs.Path{"q"}}
+	u.ApplyTo(types.S8(""))
+}
+
+func TestUpdateRevert(t *testing.T) {
+	initial := refs.Container{
+		Value: types.M{
+			"ok":    changes.Nil,
+			"bok":   changes.Nil,
+			"loki":  changes.Nil,
+			"array": types.A{changes.Nil, changes.Nil, changes.Nil, changes.Nil, changes.Nil},
+		},
+	}
+	initial, _ = initial.UpdateRef("goo", refs.Path{"Value", "ok"})
+	initial, _ = initial.UpdateRef("array", refs.Path{"Value", "array", 1})
+
+	changes := []refs.Update{
+		{"goo", refs.Path{"Value", "ok"}, nil},
+		{"goo", refs.Path{"Value", "ok"}, refs.Path{"Value", "array", 1}},
+		{"boo", nil, refs.Path{"Value", "ok"}},
+	}
+	for _, ch := range changes {
+		reverted := initial.Apply(ch).Apply(ch.Revert())
+		if !reflect.DeepEqual(initial, reverted) {
+			t.Error("Failed to revert", ch)
+		}
+	}
+}
+
+func TestContainer(t *testing.T) {
+	initial := refs.Container{Value: types.S8("OK")}
+	x, c := initial.UpdateRef("boo", nil)
+	if !reflect.DeepEqual(x, initial) || c != nil {
+		t.Error("nil update", x, c)
+	}
+
+	v, _ := initial.UpdateRef("boo", refs.Path{"Value"})
+	p := v.GetRef("boo")
+	if !reflect.DeepEqual(p, refs.Path{"Value"}) {
+		t.Error("GetRef failed")
+	}
+
+	vx := initial.Apply(changes.ChangeSet{refs.Update{"boo", nil, refs.Path{"Value"}}})
+	if !reflect.DeepEqual(vx, v) {
+		t.Error("Apply failed", vx, v)
+	}
+
+	v, _ = v.UpdateRef("boo", nil)
+	if !reflect.DeepEqual(v, initial) {
+		t.Error("Removing refs failed", v)
+	}
+}
+
+func TestContainerPanics(t *testing.T) {
+	mustPanic := func(msg string, fn func()) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("Failed to panic", msg)
+			}
+		}()
+		fn()
+	}
+
+	con := refs.Container{Value: types.S8("hello")}
+	mustPanic("bad apply", func() {
+		con.Apply(changes.Move{2, 2, 2})
+	})
+	mustPanic("bad path apply", func() {
+		con.Apply(changes.PathChange{refs.Path{"zoo"}, changes.Move{2, 2, 2}})
+	})
+	mustPanic("slice", func() {
+		con.Slice(0, 0)
+	})
+	mustPanic("count", func() {
+		con.Count()
+	})
+}

--- a/refs/update.go
+++ b/refs/update.go
@@ -1,0 +1,109 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package refs
+
+import "github.com/dotchain/dot/changes"
+
+// Update implements changes.Change interface. All updates
+// of references at the container level can only be done  using this
+// interface. Nil is not a valid value for a ref and as such can be
+// used to indicate the ref didn't exist before or to delete a ref
+//
+// Unlike most changes, Update is a bit improper. The value of the
+// reference is modified by unrelated changes. For example, deleting
+// of an element can invalidate or modify the path. This has an
+// unfortunate side-effect: Reverts may not restore the references
+// perfectly.
+type Update struct {
+	Key           interface{}
+	Before, After Ref
+}
+
+// Revert implements changes.Change
+func (u Update) Revert() changes.Change {
+	return Update{u.Key, u.After, u.Before}
+}
+
+// Merge implements changes.Change
+func (u Update) Merge(c changes.Change) (cx, ux changes.Change) {
+	switch c := c.(type) {
+	case nil:
+		return nil, u
+	case changes.Replace:
+		c.Before = c.Before.Apply(u)
+		return c, nil
+	case changes.PathChange:
+		if len(c.Path) == 0 {
+			return u.Merge(c.Change)
+		}
+
+		before := u.mergeRef(u.Before, c)
+		after := u.mergeRef(u.After, c)
+		if after == nil && before == nil {
+			return c, nil
+		}
+		return c, Update{u.Key, before, after}
+	case Update:
+		return u.merge(c)
+	case changes.Custom:
+		l, r := c.ReverseMerge(u)
+		return r, l
+	}
+	panic("Unknown change type to merge with")
+}
+
+// ReverseMerge implements changes.Custom
+func (u Update) ReverseMerge(c changes.Change) (cx, ux changes.Change) {
+	switch c := c.(type) {
+	case nil:
+		return nil, u
+	case changes.Replace:
+		c.Before = c.Before.Apply(u)
+		return c, nil
+	case changes.PathChange:
+		if len(c.Path) == 0 {
+			return u.ReverseMerge(c.Change)
+		}
+
+		before := u.mergeRef(u.Before, c)
+		after := u.mergeRef(u.After, c)
+		if after == nil && before == nil {
+			return c, nil
+		}
+		return c, Update{u.Key, before, after}
+	case Update:
+		l, r := c.merge(u)
+		return r, l
+	case changes.Custom:
+		l, r := c.Merge(u)
+		return r, l
+	}
+	panic("Unknown change type to merge with")
+}
+
+// ApplyTo implements changes.Custom
+func (u Update) ApplyTo(v changes.Value) changes.Value {
+	if con, ok := v.(Container); ok {
+		return con.Apply(u)
+	}
+	panic("Update does not implement ApplyTo")
+}
+
+func (u Update) merge(c Update) (cx, ux changes.Change) {
+	if u.Key != c.Key {
+		return c, u
+	}
+	return Update{c.Key, u.After, c.After}, nil
+}
+
+func (u Update) mergeRef(r Ref, c changes.Change) Ref {
+	if r != nil {
+		r, _ = r.Merge(c)
+	}
+	if r == InvalidRef {
+		return nil
+	}
+	return r
+}


### PR DESCRIPTION
Consider two changes: set a ref path to be [x, 5] and insert an item
at index zero into arry at [x]

If these were done with regular change.Replace and change.Splice,
it would appear as if the two changes do not conflict.  It would
cause the ref path to be [x, 5] instead of [x, 6].

The Update operation is a special version of changes.Replace for
setting references and it correctly handles the merge.

The existing composition techniques with change.PathChange forces
a constraint on Update: It can only be merged with other changes
at the same "path".  So, if an Update refers to a path outside
(such as ../z/5) and changes happen on that path, it wont be properly
merged with it.

refs.Container works around this constraint by requiring that all
references are effectively to its own children. It wraps an arbitrary
value and also exposes ability to manage references within.

The main initial use case is streams/text/Editable which would need
to a set of "selections" to regions of the text.