### PR TITLE
Add ui/collab with a cleaner interface for collaborative text

### DIFF
--- a/ui/collab/node.go
+++ b/ui/collab/node.go
@@ -1,0 +1,143 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reservet.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package collab
+
+import (
+	"github.com/dotchain/dot/refs"
+	"github.com/dotchain/dot/ui/dom"
+	"sort"
+)
+
+// Node implements dom.Node on top of a Text value
+func Node(t Text) dom.Node {
+	return node(t)
+}
+
+type node Text
+
+func (n node) Tag() string {
+	return "div"
+}
+
+func (n node) Key() interface{} {
+	return nil
+}
+
+func (n node) ForEachAttribute(fn func(key string, val interface{})) {
+	fn("contenteditable", "true")
+}
+
+func (n node) ForEachNode(fn func(n dom.Node)) {
+	last := 0
+	n.forEachCaret(last, fn)
+	for _, next := range n.indices() {
+		if next > 0 {
+			n.forEachRange(last, next, fn)
+			last = next
+			n.forEachCaret(last, fn)
+		}
+	}
+	if size := len(n.Text); size > last {
+		n.forEachRange(last, size, fn)
+		n.forEachCaret(size, fn)
+	}
+}
+
+func (n node) indices() []int {
+	indices := map[int]bool{}
+	result := []int(nil)
+	for _, ref := range n.Refs {
+		indices[ref.(refs.Range).Start.Index] = true
+		indices[ref.(refs.Range).End.Index] = true
+	}
+	for idx := range indices {
+		result = append(result, idx)
+	}
+	sort.Ints(result)
+	return result
+}
+
+func (n node) forEachCaret(idx int, fn func(dom.Node)) {
+	var own, other bool
+	for id, ref := range n.Refs {
+		s, e := ref.(refs.Range).Start.Index, ref.(refs.Range).End.Index
+		if s == e && s == idx {
+			own = own || (id == n.SessionID)
+			other = other || (id != n.SessionID)
+		}
+	}
+	switch {
+	case own && other:
+		fn(region{"caret both", ""})
+	case own:
+		fn(region{"caret own", ""})
+	case other:
+		fn(region{"caret other", ""})
+	}
+}
+
+func (n node) forEachRange(start, end int, fn func(dom.Node)) {
+	var own, other bool
+	for id, ref := range n.Refs {
+		s, e := ref.(refs.Range).Start.Index, ref.(refs.Range).End.Index
+		if s <= start && e >= end || e <= start && s >= end {
+			own = own || (id == n.SessionID)
+			other = other || (id != n.SessionID)
+		}
+	}
+
+	text := n.Text[start:end]
+	switch {
+	case own && other:
+		fn(region{"range both", text})
+	case own:
+		fn(region{"range own", text})
+	case other:
+		fn(region{"range other", text})
+	default:
+		fn(region{"", text})
+	}
+}
+
+type region struct {
+	class, text string
+}
+
+func (r region) Tag() string {
+	return "span"
+}
+
+func (r region) Key() interface{} {
+	return nil
+}
+
+func (r region) ForEachAttribute(fn func(key string, val interface{})) {
+	if r.class != "" {
+		fn("class", r.class)
+	}
+}
+
+func (r region) ForEachNode(fn func(n dom.Node)) {
+	if r.text != "" {
+		fn(textnode(r.text))
+	}
+}
+
+type textnode string
+
+func (t textnode) Tag() string {
+	return ":text:"
+}
+
+func (t textnode) Key() interface{} {
+	return nil
+}
+
+func (t textnode) ForEachAttribute(fn func(key string, val interface{})) {
+	fn(":data:", string(t))
+}
+
+func (t textnode) ForEachNode(fn func(n dom.Node)) {
+}

--- a/ui/collab/node_test.go
+++ b/ui/collab/node_test.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reservet.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package collab_test
+
+import (
+	"fmt"
+	"github.com/dotchain/dot/refs"
+	"github.com/dotchain/dot/ui/collab"
+	"github.com/dotchain/dot/ui/html"
+	"github.com/yosssi/gohtml"
+)
+
+var p = refs.Path{"Value"}
+
+func ExampleNode_overlappingRegions() {
+	v := collab.Text{
+		Text:      "Hello World",
+		SessionID: "me",
+		Refs: map[interface{}]refs.Ref{
+			"me":    refs.Range{refs.Caret{p, 1, true}, refs.Caret{p, 4, true}},
+			"alpha": refs.Range{refs.Caret{p, 0, true}, refs.Caret{p, 2, true}},
+			"beta":  refs.Range{refs.Caret{p, 4, true}, refs.Caret{p, 5, true}},
+			"gamma": refs.Range{refs.Caret{p, 5, true}, refs.Caret{p, 5, true}},
+		},
+		Stream: nil,
+	}
+
+	r := html.Reconciler.Reconcile(nil, collab.Node(v))
+	condense := gohtml.Condense
+	defer func() {
+		gohtml.Condense = condense
+	}()
+	gohtml.Condense = true
+	fmt.Printf("%s", gohtml.Format(fmt.Sprintf("%v", r)))
+
+	// Output:
+	// <div contenteditable="true">
+	//   <span class="range other">H</span>
+	//   <span class="range both">e</span>
+	//   <span class="range own">ll</span>
+	//   <span class="range other">o</span>
+	//   <span class="caret other"></span>
+	//   <span> World</span>
+	// </div>
+}
+
+func ExampleNode_carets() {
+	v := collab.Text{
+		Text:      "Hello World",
+		SessionID: "me",
+		Refs: map[interface{}]refs.Ref{
+			"me":    refs.Range{refs.Caret{p, 2, true}, refs.Caret{p, 2, true}},
+			"alpha": refs.Range{refs.Caret{p, 1, true}, refs.Caret{p, 1, true}},
+			"beta":  refs.Range{refs.Caret{p, 1, true}, refs.Caret{p, 1, true}},
+			"gamma": refs.Range{refs.Caret{p, 1, true}, refs.Caret{p, 1, true}},
+		},
+		Stream: nil,
+	}
+
+	r := html.Reconciler.Reconcile(nil, collab.Node(v))
+	condense := gohtml.Condense
+	defer func() {
+		gohtml.Condense = condense
+	}()
+	gohtml.Condense = true
+	fmt.Printf("%s", gohtml.Format(fmt.Sprintf("%v", r)))
+
+	// Output:
+	// <div contenteditable="true">
+	//   <span>H</span>
+	//   <span class="caret other"></span>
+	//   <span>e</span>
+	//   <span class="caret own"></span>
+	//   <span>llo World</span>
+	// </div>
+}
+
+func ExampleNode_sharedCarets() {
+	v := collab.Text{
+		Text:      "Hello World",
+		SessionID: "me",
+		Refs: map[interface{}]refs.Ref{
+			"me":    refs.Range{refs.Caret{p, 1, true}, refs.Caret{p, 1, true}},
+			"alpha": refs.Range{refs.Caret{p, 1, true}, refs.Caret{p, 1, true}},
+			"beta":  refs.Range{refs.Caret{p, 1, true}, refs.Caret{p, 1, true}},
+			"gamma": refs.Range{refs.Caret{p, 1, true}, refs.Caret{p, 1, true}},
+		},
+		Stream: nil,
+	}
+
+	r := html.Reconciler.Reconcile(nil, collab.Node(v))
+	condense := gohtml.Condense
+	defer func() {
+		gohtml.Condense = condense
+	}()
+	gohtml.Condense = true
+	fmt.Printf("%s", gohtml.Format(fmt.Sprintf("%v", r)))
+
+	// Output:
+	// <div contenteditable="true">
+	//   <span>H</span>
+	//   <span class="caret both"></span>
+	//   <span>ello World</span>
+	// </div>
+}

--- a/ui/collab/text.go
+++ b/ui/collab/text.go
@@ -1,0 +1,244 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reservet.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+// Package collab implements a collaborative text control
+package collab
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/refs"
+	"github.com/dotchain/dot/streams"
+	"github.com/dotchain/dot/x/types"
+	"golang.org/x/text/unicode/norm"
+)
+
+// Text is an immutable collaborative text edit control.
+type Text struct {
+	// Text is the raw text
+	Text string
+
+	// SessionID uniquely defines the current "session"
+	SessionID interface{}
+
+	// Refs contain collaborative and own cursors. Each reference
+	// in this map is a refs.Range type and the key is the
+	// SessionID.  A new session may not have any cursor until an
+	// edit or cursor movement.
+	Refs map[interface{}]refs.Ref
+
+	// Stream is used to track changes. A trivial streams.New()
+	// call can be used to create one.
+	Stream streams.Stream
+}
+
+var p = refs.Path{"Value"}
+
+// SetSelection sets the selection range for the current session
+func (t Text) SetSelection(start, end int, left bool) (Text, changes.Change) {
+	startc := refs.Caret{p, start, start > end || start == end && left}
+	endc := refs.Caret{p, end, start < end || start == end && left}
+	l, c := t.toList().UpdateRef(t.SessionID, refs.Range{startc, endc})
+	return t.fromList(l, c), c
+}
+
+// Insert inserts strings at the current cursor position.  If the
+// cursor is not collapsed, it replaces the selection and collapses
+// the cursor)
+func (t Text) Insert(s string) (Text, changes.Change) {
+	offset, before := t.selection()
+	after := types.S8(s)
+	splice := changes.PathChange{p, changes.Splice{offset, before, after}}
+	l := t.toList().Apply(splice).(refs.Container)
+	caret := refs.Caret{p, offset + after.Count(), false}
+	lx, cx := l.UpdateRef(t.SessionID, refs.Range{caret, caret})
+	cx = changes.ChangeSet{splice, cx}
+	return t.fromList(lx, cx), cx
+}
+
+// Delete deletes the selection. In the case of a collapsed selection,
+// it deletes the last character
+func (t Text) Delete() (Text, changes.Change) {
+	offset, before := t.selection()
+	if offset == 0 && string(before) == "" {
+		return t, nil
+	}
+
+	after := types.S8("")
+	caret := refs.Caret{p, offset, true}
+
+	if string(before) == "" {
+		caret.Index = offset - t.PrevCharWidth(offset)
+		before = types.S8(t.Text[caret.Index:offset])
+		offset = caret.Index
+	}
+
+	splice := changes.PathChange{p, changes.Splice{offset, before, after}}
+	l := t.toList()
+	lx, cx := l.UpdateRef(t.SessionID, refs.Range{caret, caret})
+	lx = lx.Apply(splice).(refs.Container)
+	cx = changes.ChangeSet{cx, splice}
+	return t.fromList(lx, cx), cx
+}
+
+// ArrowLeft implements left arrow key, taking care to properly account
+// for unicode sequences.
+func (t Text) ArrowLeft() (Text, changes.Change) {
+	_, end := t.cursor()
+	end -= t.PrevCharWidth(end)
+	return t.SetSelection(end, end, true)
+}
+
+// ShiftArrowLeft implements shift left arrow key, taking care to
+// properly account for unicode sequences.
+func (t Text) ShiftArrowLeft() (Text, changes.Change) {
+	start, end := t.cursor()
+	return t.SetSelection(start, end-t.PrevCharWidth(end), true)
+}
+
+// ArrowRight implements right arrow key, taking care to properly account
+// for unicode sequences.
+func (t Text) ArrowRight() (Text, changes.Change) {
+	_, end := t.cursor()
+	end += t.NextCharWidth(end)
+	return t.SetSelection(end, end, false)
+}
+
+// ShiftArrowRight implements shift right arrow key, taking care to
+// properly account for unicode sequences.
+func (t Text) ShiftArrowRight() (Text, changes.Change) {
+	start, end := t.cursor()
+	return t.SetSelection(start, end+t.NextCharWidth(end), false)
+}
+
+// Copy does not change Text.  It just returns the text currently
+// selectet.
+func (t Text) Copy() string {
+	_, sel := t.selection()
+	return string(sel)
+}
+
+// StartOf returns the cursor index of the specified session. If the
+// session does not exist, it default to zero index.
+func (t Text) StartOf(sessionID interface{}) (int, bool) {
+	if r, ok := t.Refs[sessionID]; ok {
+		caret := r.(refs.Range).Start
+		return caret.Index, caret.IsLeft
+	}
+	return 0, true
+}
+
+// EndOf returns the cursor index of the specified session.
+func (t Text) EndOf(sessionID interface{}) (int, bool) {
+	if r, ok := t.Refs[sessionID]; ok {
+		caret := r.(refs.Range).End
+		return caret.Index, caret.IsLeft
+	}
+	return 0, true
+}
+
+// Paste is like insert except it keeps the cursor around the pasted
+// string.
+func (t Text) Paste(s string) (Text, changes.Change) {
+	offset, before := t.selection()
+	after := types.S8(s)
+	splice := changes.PathChange{p, changes.Splice{offset, before, after}}
+	l := t.toList().Apply(splice).(refs.Container)
+	start := refs.Caret{p, offset, after.Count() == 0}
+	end := refs.Caret{p, offset + after.Count(), true}
+	lx, cx := l.UpdateRef(t.SessionID, refs.Range{start, end})
+	cx = changes.ChangeSet{splice, cx}
+	return t.fromList(lx, cx), cx
+}
+
+// Next returns the next value of data as determined from the
+// stream. The boolean param is set to false if there is no next value
+// or if the next value is not a valit Text.
+func (t Text) Next() (Text, bool) {
+	if s, c := t.Stream.Next(); s != nil {
+		if result, ok := t.Apply(c).(Text); ok {
+			result.Stream = s
+			return result, true
+		}
+	}
+	return t, false
+}
+
+// Latest returns the latest value of the data
+func (t Text) Latest() Text {
+	var ok bool
+	for t, ok = t.Next(); ok; t, ok = t.Next() {
+	}
+	return t
+}
+
+// Apply implements changes.Value. Note that this does not update the
+// stream and as such should be used with care.
+func (t Text) Apply(c changes.Change) changes.Value {
+	result := t.toList().Apply(c)
+	if l, ok := result.(refs.Container); ok {
+		text := string(l.Value.(types.S8))
+		return Text{text, t.SessionID, l.Refs(), nil}
+	}
+	return result
+}
+
+func (t Text) cursor() (int, int) {
+	if r, ok := t.Refs[t.SessionID]; ok {
+		return r.(refs.Range).Start.Index, r.(refs.Range).End.Index
+	}
+	return 0, 0
+}
+
+func (t Text) toList() refs.Container {
+	return refs.NewContainer(types.S8(t.Text), t.Refs)
+}
+
+func (t Text) fromList(l refs.Container, c changes.Change) Text {
+	text := string(l.Value.(types.S8))
+	return Text{text, t.SessionID, l.Refs(), t.Stream.Append(c)}
+}
+
+func (t Text) selection() (int, types.S8) {
+	start, end := t.cursor()
+	if start > end {
+		start, end = end, start
+	}
+	return start, types.S8(t.Text[start:end])
+}
+
+// NextCharWidth returns the width of a user-perceived character.  This
+// takes care of combining characters and such.
+func (t Text) NextCharWidth(idx int) int {
+	return norm.NFC.NextBoundaryInString(t.Text[idx:], true)
+}
+
+// PrevCharWidth returns the width of a user-perceived character
+// before the provided index.  This takes care of combining characters
+// and such.
+func (t Text) PrevCharWidth(idx int) int {
+	text := []byte(t.Text)[:idx]
+
+	offset := norm.NFC.LastBoundary(text)
+	if offset < 0 {
+		return 0
+	}
+
+	if offset < idx || idx == 0 {
+		return idx - offset
+	}
+
+	// NFC.LastBoundary is quite buggy in some cases.
+	// See: https://github.com/golang/go/issues/9055
+	// The work around is to brute force it in those cases
+	idx = len(text) - 100
+	if idx < 0 {
+		idx = 0
+	}
+	w := len(text) - idx
+	for w > 1 && norm.NFC.NextBoundary(text[idx:], true) != w {
+		idx++
+		w--
+	}
+	return w
+}

--- a/ui/collab/text_test.go
+++ b/ui/collab/text_test.go
@@ -1,0 +1,388 @@
+// Copyright (C) 2018 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package collab_test
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/refs"
+	"github.com/dotchain/dot/streams"
+	"github.com/dotchain/dot/ui/collab"
+	"github.com/dotchain/dot/x/types"
+	"reflect"
+	"testing"
+)
+
+func TestText(t *testing.T) {
+	(textSuite{}).Run(t)
+}
+
+type textSuite struct{}
+
+func (s textSuite) Run(t *testing.T) {
+	t.Run("Cursors", s.testTextCursors)
+	t.Run("CaretRemoteInsertion", s.testCaretRemoteInsertion)
+	t.Run("InsertCollapsed", s.testTextInsertCollapsed)
+	t.Run("InsertNonCollapsed", s.testTextInsertNonCollapsed)
+	t.Run("PasteCollapsed", s.testTextPasteCollapsed)
+	t.Run("PasteNonCollapsed", s.testTextPasteNonCollapsed)
+	t.Run("DeleteCollapsed", s.testTextDeleteCollapsed)
+	t.Run("DeleteNonCollapsed", s.testTextDeleteNonCollapsed)
+	t.Run("EmptyDelete", s.testEmptyDelete)
+	t.Run("Replace", s.testReplace)
+	t.Run("CharWidths", s.testCharWidths)
+	t.Run("ArrowRightLeft", s.testArrowRightLeft)
+	t.Run("ShiftArrowLeft", s.testShiftArrowLeft)
+	t.Run("ShiftArrowRight", s.testShiftArrowRight)
+	t.Run("Latest", s.testLatest)
+}
+
+func (s textSuite) text(txt string) collab.Text {
+	return collab.Text{txt, nil, map[interface{}]refs.Ref{}, streams.New()}
+}
+
+func (s textSuite) validate(t *testing.T, c changes.Change, before, after collab.Text) collab.Text {
+	before.Stream = streams.New()
+	before.Stream.Append(c)
+
+	next, ok := before.Next()
+	if !ok || !reflect.DeepEqual(next, after) {
+		t.Fatal("change diverged", c)
+	}
+
+	next.Stream = streams.New()
+	next.Stream.Append((changes.ChangeSet{c}).Revert())
+	reverted, _ := next.Next()
+
+	if reverted.Text != before.Text {
+		t.Fatal("revert diverged", before.Text, reverted.Text)
+	}
+
+	start, left := before.StartOf(before.SessionID)
+	rstart, rleft := reverted.StartOf(reverted.SessionID)
+	if start != rstart || left != rleft {
+		t.Fatal("revert diverged", start, left, rstart, rleft, c)
+	}
+
+	end, left := before.EndOf(before.SessionID)
+	rend, rleft := reverted.EndOf(reverted.SessionID)
+	if end != rend || left != rleft {
+		t.Fatal("revert diverged", end, left, rend, rleft, c)
+	}
+
+	return after
+}
+
+func (s textSuite) testTextCursors(t *testing.T) {
+	x := s.text("Hello")
+	x2, c := x.SetSelection(3, 3, false)
+	x = s.validate(t, c, x, x2)
+	x2, c = x.SetSelection(3, 5, false)
+	x = s.validate(t, c, x, x2)
+
+	if sel := x.Copy(); sel != "lo" {
+		t.Error("Unexpected copy failure", sel)
+	}
+
+	// make start > end
+	x2, c = x.SetSelection(5, 3, true)
+	x = s.validate(t, c, x, x2)
+
+	if sel := x.Copy(); sel != "lo" {
+		t.Error("Unexpected copy failure", sel)
+	}
+}
+
+func (s textSuite) testCaretRemoteInsertion(t *testing.T) {
+	insert := changes.Splice{3, types.S8(""), types.S8("book")}
+	cx := changes.PathChange{[]interface{}{"Value"}, insert}
+
+	for _, isLeft := range []bool{true, false} {
+		x := s.text("Hello")
+		x2, c := x.SetSelection(3, 3, isLeft)
+		x = s.validate(t, c, x, x2)
+
+		x.Stream.Append(cx)
+		x2, _ = x.Next()
+		x = s.validate(t, cx, x, x2)
+
+		expected := 3
+		if !isLeft {
+			expected += insert.After.Count()
+		}
+
+		if start, _ := x.StartOf(x.SessionID); start != expected {
+			t.Error("Unexpected start", start, expected)
+		}
+		if end, _ := x.EndOf(x.SessionID); end != expected {
+			t.Error("Unexpected end", end, expected)
+		}
+	}
+}
+
+func (s textSuite) testTextInsertCollapsed(t *testing.T) {
+	x := s.text("Hello")
+	x2, c := x.SetSelection(3, 3, true)
+	x = s.validate(t, c, x, x2)
+
+	x2, c = x.Insert("<boo>")
+	x = s.validate(t, c, x, x2)
+
+	if x.Text != "Hel<boo>lo" {
+		t.Error("Unexpected insert text", x.Text)
+	}
+
+	if start, left := x.StartOf(x.SessionID); start != len("Hel<boo>") || left {
+		t.Error("Unexpected start", start, left)
+	}
+
+	if end, left := x.EndOf(x.SessionID); end != len("Hel<boo>") || left {
+		t.Error("Unexpected end", end, left)
+	}
+}
+
+func (s textSuite) testTextInsertNonCollapsed(t *testing.T) {
+	x := s.text("HelOKlo")
+	x2, c := x.SetSelection(3, 5, false)
+	x = s.validate(t, c, x, x2)
+
+	x2, c = x.Insert("<boo>")
+	x = s.validate(t, c, x, x2)
+
+	if x.Text != "Hel<boo>lo" {
+		t.Error("Unexpected insert text", x.Text)
+	}
+
+	if start, left := x.StartOf(x.SessionID); start != len("Hel<boo>") || left {
+		t.Error("Unexpected start", start, left)
+	}
+
+	if end, left := x.EndOf(x.SessionID); end != len("Hel<boo>") || left {
+		t.Error("Unexpected end", end, left)
+	}
+}
+
+func (s textSuite) testTextPasteCollapsed(t *testing.T) {
+	x := s.text("Hello")
+	x2, c := x.SetSelection(3, 3, false)
+	x = s.validate(t, c, x, x2)
+
+	x2, c = x.Paste("<boo>")
+	x = s.validate(t, c, x, x2)
+
+	if x.Text != "Hel<boo>lo" {
+		t.Error("Unexpected insert text", x.Text)
+	}
+
+	if start, left := x.StartOf(x.SessionID); start != len("Hel") || left {
+		t.Error("Unexpected start", start, left)
+	}
+
+	if end, left := x.EndOf(x.SessionID); end != len("Hel<boo>") || !left {
+		t.Error("Unexpected end", end, left)
+	}
+}
+
+func (s textSuite) testTextPasteNonCollapsed(t *testing.T) {
+	x := s.text("HelOKlo")
+	x2, c := x.SetSelection(3, 5, false)
+	x = s.validate(t, c, x, x2)
+
+	x2, c = x.Paste("<boo>")
+	x = s.validate(t, c, x, x2)
+
+	if x.Text != "Hel<boo>lo" {
+		t.Error("Unexpected insert text", x.Text)
+	}
+
+	if start, left := x.StartOf(x.SessionID); start != len("Hel") || left {
+		t.Error("Unexpected start", start, left)
+	}
+
+	if end, left := x.EndOf(x.SessionID); end != len("Hel<boo>") || !left {
+		t.Error("Unexpected end", end, left)
+	}
+}
+
+func (s textSuite) testTextDeleteCollapsed(t *testing.T) {
+	x := s.text("HelOKlo")
+	x2, c := x.SetSelection(3, 3, false)
+	x = s.validate(t, c, x, x2)
+
+	x2, c = x.Delete()
+	x = s.validate(t, c, x, x2)
+
+	if x.Text != "HeOKlo" {
+		t.Error("Unexpected insert text", x.Text)
+	}
+
+	if start, left := x.StartOf(x.SessionID); start != len("He") || !left {
+		t.Error("Unexpected start", start, left)
+	}
+
+	if end, left := x.EndOf(x.SessionID); end != len("He") || !left {
+		t.Error("Unexpected end", end, left)
+	}
+}
+
+func (s textSuite) testTextDeleteNonCollapsed(t *testing.T) {
+	x := s.text("HelOKlo")
+	x2, c := x.SetSelection(3, 5, false)
+	x = s.validate(t, c, x, x2)
+
+	x2, c = x.Delete()
+	x = s.validate(t, c, x, x2)
+
+	if x.Text != "Hello" {
+		t.Error("Unexpected insert text", x.Text)
+	}
+
+	if start, left := x.StartOf(x.SessionID); start != len("Hel") || !left {
+		t.Error("Unexpected start", start, left)
+	}
+
+	if end, left := x.EndOf(x.SessionID); end != len("Hel") || !left {
+		t.Error("Unexpected end", end, left)
+	}
+}
+
+func (s textSuite) testEmptyDelete(t *testing.T) {
+	x := s.text("HelOKlo")
+	x2, c := x.SetSelection(0, 0, false)
+	x = s.validate(t, c, x, x2)
+
+	x2, c = x.Delete()
+	s.validate(t, c, x, x2)
+
+	if !reflect.DeepEqual(x, x2) || c != nil {
+		t.Error("Unexpected delete behavior", x2, c)
+	}
+}
+
+func (s textSuite) testReplace(t *testing.T) {
+	x := s.text("HelOKlo")
+	result := x.Apply(changes.Replace{x, types.S8("boo")})
+	if result != types.S8("boo") {
+		t.Error("Unexpected Next", result)
+	}
+
+	x.Stream.Append(changes.Replace{x, types.S8("boo")})
+	if _, ok := x.Next(); ok {
+		t.Error("Unexpected Next value")
+	}
+}
+
+func (s textSuite) testCharWidths(t *testing.T) {
+	x := s.text("bròwn")
+	w := x.NextCharWidth(2)
+	if x.Text[2:2+w] != "ò" {
+		t.Error("NextCharWidth unexpected", w)
+	}
+	if x := x.PrevCharWidth(2 + w); x != w {
+		t.Error("PrevCharWidth unexpected", x)
+	}
+
+	if x.PrevCharWidth(0) != 0 {
+		t.Error("PrevCharWidth(0)", x.PrevCharWidth(0))
+	}
+
+	// ensure that prev char width works with " ", "!" and "♔"
+	// and agonek a = agonek + acute: "\u0061\u0328\u0301"
+	for _, choice := range []string{" ", "!", "♔", "\u0061\u0328\u0301"} {
+		x = s.text("x" + choice)
+		w = x.NextCharWidth(1)
+		if w != len(choice) {
+			t.Fatal("NextCharWidth gave odd answer", choice, w)
+		}
+		if w2 := x.PrevCharWidth(1 + w); w2 != len(choice) {
+			t.Error("PrevCharWidth gave odd answer", choice, w, w2)
+		}
+	}
+}
+
+func (s textSuite) testArrowRightLeft(t *testing.T) {
+	// lets test out some agontek magic: a + ogonek + acute
+	x := s.text("\u0061\u0328\u0301")
+	after, c := x.ArrowRight()
+	s.validate(t, c, x, after)
+	if x.Text != after.Text {
+		t.Error("Unexpected value change", after.Text)
+	}
+
+	if start, left := after.StartOf(x.SessionID); left || start != len(x.Text) {
+		t.Error("Unexpected start value", left, start)
+	}
+
+	if end, left := after.EndOf(x.SessionID); left || end != len(x.Text) {
+		t.Error("Unexpected end value", left, end)
+	}
+
+	x, c = after.ArrowLeft()
+	s.validate(t, c, after, x)
+
+	if x.Text != after.Text {
+		t.Error("Unexpected value change", x.Text)
+	}
+
+	if start, left := x.StartOf(x.SessionID); !left || start != 0 {
+		t.Error("Unexpected start value", left, start)
+	}
+
+	if end, left := x.EndOf(x.SessionID); !left || end != 0 {
+		t.Error("Unexpected end value", left, end)
+	}
+}
+
+func (s textSuite) testShiftArrowLeft(t *testing.T) {
+	// lets test out some agontek magic: a + ogonek + acute
+	x := s.text("\u0061\u0328\u0301")
+	x, _ = x.SetSelection(len(x.Text), len(x.Text), false)
+	after, c := x.ShiftArrowLeft()
+	s.validate(t, c, x, after)
+	if x.Text != after.Text {
+		t.Error("Unexpected value change", after.Text)
+	}
+
+	if start, left := after.StartOf(x.SessionID); !left || start != len(x.Text) {
+		t.Error("Unexpected start value", left, start)
+	}
+
+	if end, left := after.EndOf(x.SessionID); left || end != 0 {
+		t.Error("Unexpected end value", left, end)
+	}
+}
+
+func (s textSuite) testShiftArrowRight(t *testing.T) {
+	// lets test out some agontek magic: a + ogonek + acute
+	x := s.text("\u0061\u0328\u0301")
+	after, c := x.ShiftArrowRight()
+	s.validate(t, c, x, after)
+
+	if x.Text != after.Text {
+		t.Error("Unexpected value change", after.Text)
+	}
+
+	if start, left := after.StartOf(x.SessionID); left || start != 0 {
+		t.Error("Unexpected start value", left, start)
+	}
+
+	if end, left := after.EndOf(x.SessionID); !left || end != len(x.Text) {
+		t.Error("Unexpected end value", left, end)
+	}
+}
+
+func (s textSuite) testLatest(t *testing.T) {
+	p := func(c changes.Change) changes.Change {
+		return changes.PathChange{[]interface{}{"Value"}, c}
+	}
+	x := s.text("hello")
+	x.Stream.
+		Append(p(changes.Splice{5, types.S8(""), types.S8(" ")})).
+		Append(p(changes.Splice{6, types.S8(""), types.S8("world")}))
+
+	latest := x.Latest()
+	if latest.Text != "hello world" {
+		t.Error("Latest unexpected", latest.Text)
+	}
+}


### PR DESCRIPTION
This refactors dot/ui/text into a  simpler structure: dot/ui/collab.Text and dot/ui/collab.Node. The former implements all the state needed and the latter implements the rendering.

Note that the latter Node structure relies on dot/ui/dom to provide reconciliation support.

Next step would be figuring out how to setup callbacks.  Ideally the callbacks are actually implemented within collab.Text as event handlers (collab.Text.On) but this would make it a bit harder to do some stuff.