### PR TITLE
UX: Add children reconciliation to examples

### DIFF
--- a/ux/children.go
+++ b/ux/children.go
@@ -9,7 +9,7 @@ package ux
 func UpdateChildren(parent Element, after []Element) {
 	before := parent.Children()
 	for _, op := range bestDiff(before, after, 0, nil) {
-		if op.insert == true {
+		if op.insert {
 			parent.InsertChild(op.index, op.elt)
 		} else {
 			parent.RemoveChild(op.index)
@@ -26,6 +26,7 @@ type diff struct {
 func bestDiff(before, after []Element, offset int, ops []diff) []diff {
 	for len(before) > 0 && len(after) > 0 && before[0] == after[0] {
 		offset++
+		before, after = before[1:], after[1:]
 	}
 
 	switch {

--- a/ux/children.go
+++ b/ux/children.go
@@ -1,0 +1,77 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package ux
+
+// UpdateChildren updates a parent node with the new set of children
+// attempting to minimize calls to RemoveChild and InsertChild
+func UpdateChildren(parent Element, after []Element) {
+	before := parent.Children()
+	for _, op := range bestDiff(before, after, 0, nil) {
+		if op.insert == true {
+			parent.InsertChild(op.index, op.elt)
+		} else {
+			parent.RemoveChild(op.index)
+		}
+	}
+}
+
+type diff struct {
+	insert bool
+	elt    Element
+	index  int
+}
+
+func bestDiff(before, after []Element, offset int, ops []diff) []diff {
+	for len(before) > 0 && len(after) > 0 && before[0] == after[0] {
+		offset++
+	}
+
+	switch {
+	case len(before) == 0:
+		for _, e := range after {
+			ops = append(ops, diff{true, e, offset})
+			offset++
+		}
+	case len(after) == 0:
+		for range before {
+			ops = append(ops, diff{false, nil, offset})
+		}
+	default:
+		ops = chooseDiff(before, after, offset, ops)
+	}
+
+	return ops
+}
+
+func chooseDiff(before, after []Element, offset int, ops []diff) []diff {
+	// choice1 = clone of ops + delete first before elt
+	choice1 := append(ops, diff{false, nil, offset})
+	choice1 = bestDiff(before[1:], after, offset, choice1)
+
+	index := indexOf(before[0], after)
+	if index == -1 {
+		return choice1
+	}
+
+	// choice2 = clone of ops + insert index after elts
+	choice2 := append([]diff(nil), ops...)
+	for kk := 0; kk < index+1; kk++ {
+		choice2 = append(choice2, diff{true, after[kk], offset + kk})
+	}
+	choice2 = bestDiff(before, after[index+1:], offset+index+1, choice2)
+	if len(choice1) < len(choice2) {
+		return choice1
+	}
+	return choice2
+}
+
+func indexOf(elt Element, elts []Element) int {
+	for kk, e := range elts {
+		if e == elt {
+			return kk
+		}
+	}
+	return -1
+}

--- a/ux/driver_test.go
+++ b/ux/driver_test.go
@@ -92,3 +92,22 @@ func (e *element) Click() {
 		cx.Handle(ux.MouseEvent{})
 	}
 }
+
+func (e *element) Children() []ux.Element {
+	return e.children
+}
+
+func (e *element) RemoveChild(index int) {
+	c := make([]ux.Element, len(e.children)-1)
+	copy(c, e.children[:index])
+	copy(c[index:], e.children[index+1:])
+	e.children = c
+}
+
+func (e *element) InsertChild(index int, elt ux.Element) {
+	c := make([]ux.Element, len(e.children)+1)
+	copy(c, e.children[:index])
+	c[index] = elt
+	copy(c[index+1:], e.children[index:])
+	e.children = c
+}

--- a/ux/todo_task_cache_test.go
+++ b/ux/todo_task_cache_test.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package ux_test
+
+import "github.com/dotchain/dot/ux"
+
+// TodoTaskCache can be generated from a template.
+type TodoTaskCache struct {
+	old, current map[string]*TodoTask
+}
+
+func (c *TodoTaskCache) Reset() {
+	c.old = c.current
+	c.current = map[string]*TodoTask{}
+}
+
+func (c *TodoTaskCache) Cleanup() {
+	// if TodoTask had a Close() method all the old left-over items
+	// can be cleaned up via that call
+	c.old = nil
+}
+
+func (c *TodoTaskCache) Get(id string, styles ux.Styles, data TaskData) (*TodoTask, bool) {
+	exists := false
+	if t, ok := c.old[id]; !ok {
+		c.current[id] = NewTodoTask(styles, data)
+	} else {
+		delete(c.old, id)
+		t.Update(styles, data)
+		c.current[id] = t
+		exists = true
+	}
+
+	return c.current[id], exists
+}

--- a/ux/todo_task_list_test.go
+++ b/ux/todo_task_list_test.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package ux_test
+
+import "github.com/dotchain/dot/ux"
+
+type TaskList struct {
+	ShowDone, ShowUndone bool
+	Tasks                []TaskData
+}
+
+type TodoTaskList struct {
+	Root       ux.Element
+	styles     ux.Styles
+	tasksCache TodoTaskCache
+}
+
+func NewTodoTaskList(styles ux.Styles, data TaskList) *TodoTaskList {
+	t := &TodoTaskList{
+		ux.NewElement(ux.Props{Tag: "div", Styles: styles}),
+		styles,
+		TodoTaskCache{},
+	}
+	t.Update(styles, data)
+	return t
+}
+
+func (t *TodoTaskList) Update(styles ux.Styles, data TaskList) {
+	if t.styles != styles {
+		t.styles = styles
+		t.Root.SetProp("Styles", styles)
+	}
+
+	children := []ux.Element{}
+	for _, td := range data.Tasks {
+		if td.Done && !data.ShowDone || !td.Done && !data.ShowUndone {
+			continue
+		}
+
+		task, exists := t.tasksCache.Get(td.ID, ux.Styles{}, td)
+		if !exists {
+			task.TaskData.On(&ux.Handler{t.on})
+		}
+		children = append(children, task.Root)
+	}
+	ux.UpdateChildren(t.Root, children)
+}
+
+func (t *TodoTaskList) on() {
+	// need to aggregate all received changes and generate the updated changes
+}

--- a/ux/todo_task_list_test.go
+++ b/ux/todo_task_list_test.go
@@ -4,7 +4,10 @@
 
 package ux_test
 
-import "github.com/dotchain/dot/ux"
+import (
+	"fmt"
+	"github.com/dotchain/dot/ux"
+)
 
 type TaskList struct {
 	ShowDone, ShowUndone bool
@@ -33,6 +36,9 @@ func (t *TodoTaskList) Update(styles ux.Styles, data TaskList) {
 		t.Root.SetProp("Styles", styles)
 	}
 
+	t.tasksCache.Reset()
+	defer t.tasksCache.Cleanup()
+
 	children := []ux.Element{}
 	for _, td := range data.Tasks {
 		if td.Done && !data.ShowDone || !td.Done && !data.ShowUndone {
@@ -50,4 +56,29 @@ func (t *TodoTaskList) Update(styles ux.Styles, data TaskList) {
 
 func (t *TodoTaskList) on() {
 	// need to aggregate all received changes and generate the updated changes
+}
+
+func Example_renderTaskList() {
+	tasks := []TaskData{
+		{"one", false, "first task"},
+		{"two", true, "second task"},
+	}
+	list := TaskList{true, false, tasks}
+	t := NewTodoTaskList(ux.Styles{}, list)
+	fmt.Println(t.Root)
+
+	list = TaskList{false, false, tasks}
+	t.Update(ux.Styles{Color: "red"}, list)
+	fmt.Println(t.Root)
+
+	list = TaskList{true, false, tasks}
+	t.Update(ux.Styles{}, list)
+	list = TaskList{true, true, tasks}
+	t.Update(ux.Styles{}, list)
+	fmt.Println(t.Root)
+
+	// Output:
+	// div[]( div[]( input[type:checkbox checked]() input[type:text](second task)))
+	// div[styles:{red}]()
+	// div[]( div[]( input[type:checkbox]() input[type:text](first task)) div[]( input[type:checkbox checked]() input[type:text](second task)))
 }

--- a/ux/todo_task_test.go
+++ b/ux/todo_task_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 type TaskData struct {
+	ID          string
 	Done        bool
 	Description string
 }
@@ -69,7 +70,8 @@ func (t *TodoTask) Update(styles ux.Styles, data TaskData) {
 }
 
 func (t *TodoTask) on() {
-	data := TaskData{t.cb.Checked.Value, t.description.Text.Value}
+	id := t.TaskData.TaskData.ID
+	data := TaskData{id, t.cb.Checked.Value, t.description.Text.Value}
 	t.TaskData = t.TaskData.Update(data)
 	t.TaskData.Notify()
 }

--- a/ux/ux.go
+++ b/ux/ux.go
@@ -23,6 +23,15 @@ type Element interface {
 
 	// Value is the equivalent of HTMLInputElement.value
 	Value() string
+
+	// Children returns a readonly slice of children
+	Children() []Element
+
+	// RemoveChild remove a child element at the provided index
+	RemoveChild(index int)
+
+	// InsertChild inserts a child element at the provided index
+	InsertChild(index int, elt Element)
 }
 
 // Styles represents a set of CSS Styles


### PR DESCRIPTION
Still needs  a bit more work cleaning up all the confusing names for models and controls as well as the ability to propagate changes up the tree but most of the structure  is in place.