### PR TITLE
ux: add declarative component embedded struct

### DIFF
--- a/ux/checkbox.go
+++ b/ux/checkbox.go
@@ -4,13 +4,15 @@
 
 package ux
 
+import "github.com/dotchain/dot/ux/core"
+
 // Checkbox implements a checkbox control.
 type Checkbox struct {
-	// Root is the root dom element of this control
-	Root Element
+	// Component is embedded. Root element is exposed through this.
+	Component
 
-	// private state
-	styles Styles
+	// persist this
+	onChangeHandler core.EventHandler
 
 	// Consumers of Checkbox can get the latest value by
 	// inspecting this field.  Changes can be subscribed by
@@ -20,27 +22,30 @@ type Checkbox struct {
 
 // NewCheckbox creates a new checkbox control.
 func NewCheckbox(styles Styles, checked bool) *Checkbox {
-	c := &Checkbox{nil, styles, &BoolStream{&Notifier{}, checked, nil, nil}}
-	c.Root = NewElement(Props{
-		Tag:      "input",
-		Type:     "checkbox",
-		Checked:  checked,
-		Styles:   styles,
-		OnChange: &EventHandler{c.onChange},
-	})
+	c := &Checkbox{}
+	c.onChangeHandler = core.EventHandler{c.onChange}
+	c.Checked = &BoolStream{&Notifier{}, checked, nil, nil}
+
+	c.render(styles)
 	return c
 }
 
-// Update updates the value and styles of the checkbox.
+// Update updates the control to use the provided styles and checked value
 func (c *Checkbox) Update(styles Styles, checked bool) {
 	if c.Checked.Value != checked {
-		c.Root.SetProp("Checked", checked)
 		c.Checked = c.Checked.Update(nil, checked)
 	}
-	if c.styles != styles {
-		c.styles = styles
-		c.Root.SetProp("Styles", styles)
-	}
+	c.render(styles)
+}
+
+func (c *Checkbox) render(styles Styles) {
+	c.Declare(core.Props{
+		Tag:      "input",
+		Type:     "checkbox",
+		Checked:  c.Checked.Value,
+		Styles:   styles,
+		OnChange: &c.onChangeHandler,
+	})
 }
 
 func (c *Checkbox) onChange(e Event) {

--- a/ux/component.go
+++ b/ux/component.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package ux
+
+import "github.com/dotchain/dot/ux/core"
+
+// Component is a simple helper class that helps with creating
+// declarative components.
+//
+// It is expected to be embedded directly and all updates are
+// specified through the Declare method.
+//
+// Usage:
+//
+//      type MyComponent struct {
+//           ux.Component,
+//           ...
+//      }
+//
+//      func NewMyComponent(....) *MyComponent {
+//           result := ....
+//           result.Declare(props, children...)
+//      }
+//
+//      func (c *MyComponent) Update(...) {
+//           c.Declare(updatedProps, updatedChildren...)
+//      }
+//
+// Note that each component still has to create all its children and
+// reuse these from previous runs. If the number of children is fixed,
+// a component can simply maintain them via named private fields (and
+// remember to update them between calls).  If the number of children
+// is dynamic, the component cache can be used (see
+// templates/cache.template and todo/tasks_view.go for example usage)
+type Component struct {
+	Root  core.Element
+	props core.Props
+}
+
+// Declare creates the component if needed or updates it to reflect
+// the new set of props and children
+func (c *Component) Declare(props core.Props, children ...core.Element) {
+	if c.Root == nil {
+		c.Root = core.NewElement(props, children...)
+		c.props = props
+		return
+	}
+
+	if c.props != props {
+		before, after := propsToMap(c.props), propsToMap(props)
+		c.props = props
+		for k, v := range after {
+			if before[k] != v {
+				c.Root.SetProp(k, v)
+			}
+		}
+	}
+	UpdateChildren(c.Root, children)
+}
+
+func propsToMap(props core.Props) map[string]interface{} {
+	return map[string]interface{}{
+		"Tag":         props.Tag,
+		"Checked":     props.Checked,
+		"Type":        props.Type,
+		"TextContent": props.TextContent,
+		"Styles":      props.Styles,
+		"OnChange":    props.OnChange,
+	}
+}

--- a/ux/core/core.go
+++ b/ux/core/core.go
@@ -9,7 +9,7 @@
 // native DOM interface is maintained here. The higher order ux
 // library has wrappers to help make things less imperative.
 //
-// All changes to this have to be backwards compatible. 
+// All changes to this have to be backwards compatible.
 package core
 
 // Driver represents the interface to be implemented by drivers. This

--- a/ux/ux.go
+++ b/ux/ux.go
@@ -98,20 +98,27 @@ import "github.com/dotchain/dot/ux/core"
 
 // Driver is a type alias
 type Driver = core.Driver
+
 // Element is a type alias
 type Element = core.Element
+
 // Styles is a type alias
 type Styles = core.Styles
+
 // Props is a type alias
 type Props = core.Props
+
 // EventHandler is a type alias
 type EventHandler = core.EventHandler
+
 // Event is a type alias
 type Event = core.Event
+
 // Change is a type alias
 type Change = core.Change
 
 // NewElement is an alias
 var NewElement = core.NewElement
+
 // RegisterDriver is an alias
 var RegisterDriver = core.RegisterDriver


### PR DESCRIPTION
This  adds a declarative component helper via the Component struct that is expected to be embedded into declarative components.

Still missing:

- [ ] A way to manage children  of multiple types. If all children are same type (like in todo/tasks_view.go), a strongly type memoizer cache can be used to keep track of invocations.  But if they are of different types, there isn't a simple way out
- [ ] A way to represent  simple nested structures : div(div, div(compx), div) is not easily specified in a  reactive way.  It is possible raw naked Components can be used (i.e. div =  Component).  Need to  test it out.

Also, does  not migrate  all the current imperative examples over.  Might find some  issues  when doing this.