### PR TITLE
ux: simplify the todo app controls  a bit

### DIFF
--- a/ux/simple/checkbox_cache.go
+++ b/ux/simple/checkbox_cache.go
@@ -45,35 +45,21 @@ func (c *CheckboxCache) End() {
 	c.old = nil
 }
 
-// TryGet fetches a Checkbox from the cache (updating it)
+// Item fetches the item at the specific key
+func (c *CheckboxCache) Item(key interface{}) *Checkbox {
+	return c.current[key]
+}
+
+// Checkbox fetches a Checkbox from the cache (updating it)
 // or creates a new Checkbox
-//
-// It returns the Checkbox but also whether the control existed.
-// This can be used to conditionally setup listeners.
-func (c *CheckboxCache) TryGet(key interface{}, styles core.Styles, checked bool) (*Checkbox, bool) {
-	exists := false
+func (c *CheckboxCache) Checkbox(key interface{}, styles core.Styles, checked bool) *Checkbox {
 	if item, ok := c.old[key]; !ok {
 		c.current[key] = NewCheckbox(styles, checked)
 	} else {
 		delete(c.old, key)
 		item.Update(styles, checked)
 		c.current[key] = item
-		exists = true
 	}
 
-	return c.current[key], exists
-}
-
-// Item fetches the item at the specific key
-func (c *CheckboxCache) Item(key interface{}) *Checkbox {
 	return c.current[key]
-}
-
-// Get fetches a Checkbox from the cache (updating it)
-// or creates a new Checkbox
-//
-// Use TryGet to also fetch whether the control from last round was reused
-func (c *CheckboxCache) Get(key interface{}, styles core.Styles, checked bool) *Checkbox {
-	v, _ := c.TryGet(key, styles, checked)
-	return v
 }

--- a/ux/simple/text_edit_cache.go
+++ b/ux/simple/text_edit_cache.go
@@ -45,35 +45,21 @@ func (c *TextEditCache) End() {
 	c.old = nil
 }
 
-// TryGet fetches a TextEdit from the cache (updating it)
+// Item fetches the item at the specific key
+func (c *TextEditCache) Item(key interface{}) *TextEdit {
+	return c.current[key]
+}
+
+// TextEdit fetches a TextEdit from the cache (updating it)
 // or creates a new TextEdit
-//
-// It returns the TextEdit but also whether the control existed.
-// This can be used to conditionally setup listeners.
-func (c *TextEditCache) TryGet(key interface{}, styles core.Styles, text string) (*TextEdit, bool) {
-	exists := false
+func (c *TextEditCache) TextEdit(key interface{}, styles core.Styles, text string) *TextEdit {
 	if item, ok := c.old[key]; !ok {
 		c.current[key] = NewTextEdit(styles, text)
 	} else {
 		delete(c.old, key)
 		item.Update(styles, text)
 		c.current[key] = item
-		exists = true
 	}
 
-	return c.current[key], exists
-}
-
-// Item fetches the item at the specific key
-func (c *TextEditCache) Item(key interface{}) *TextEdit {
 	return c.current[key]
-}
-
-// Get fetches a TextEdit from the cache (updating it)
-// or creates a new TextEdit
-//
-// Use TryGet to also fetch whether the control from last round was reused
-func (c *TextEditCache) Get(key interface{}, styles core.Styles, text string) *TextEdit {
-	v, _ := c.TryGet(key, styles, text)
-	return v
 }

--- a/ux/streams/bool.go
+++ b/ux/streams/bool.go
@@ -9,7 +9,6 @@ package streams
 
 import "github.com/dotchain/dot/changes"
 
-
 // BoolStream holds a Bool value and tracks changes to it.
 //
 // Changes can be listened to via the embedded Notifier.  Actual

--- a/ux/streams/text.go
+++ b/ux/streams/text.go
@@ -9,7 +9,6 @@ package streams
 
 import "github.com/dotchain/dot/changes"
 
-
 // TextStream holds a Text value and tracks changes to it.
 //
 // Changes can be listened to via the embedded Notifier.  Actual

--- a/ux/templates/cache.template
+++ b/ux/templates/cache.template
@@ -45,36 +45,21 @@ func (c *{{.Base}}Cache) End() {
 	c.old = nil
 }
 
-
-// TryGet fetches a {{.BaseType}} from the cache (updating it)
-// or creates a new {{.BaseType}}
-//
-// It returns the {{.BaseType}} but also whether the control existed.
-// This can be used to conditionally setup listeners.
-func (c *{{.Base}}Cache) TryGet(key interface{}, {{.ArgsDef}}) (*{{.BaseType}}, bool) {
-	exists := false
-	if item, ok := c.old[key]; !ok {
-		c.current[key] = {{.Constructor}}({{.Args}})
-	} else {
-		delete(c.old, key)
-		item.Update({{.Args}})
-		c.current[key] = item
-		exists = true
-	}
-
-	return c.current[key], exists
-}
-
 // Item fetches the item at the specific key
 func (c *{{.Base}}Cache) Item(key interface{}) *{{.BaseType}} {
-	return c.current[key]
+       return c.current[key]
 }
 
 // {{.Base}} fetches a {{.BaseType}} from the cache (updating it)
 // or creates a new {{.BaseType}}
-//
-// Use TryGet to also fetch whether the control from last round was reused
 func (c *{{.Base}}Cache) {{.Base}}(key interface{}, {{.ArgsDef}}) *{{.BaseType}} {
-	v, _ := c.TryGet(key, {{.Args}})
-        return v
+       if item, ok := c.old[key]; !ok {
+               c.current[key] = {{.Constructor}}({{.Args}})
+       } else {
+               delete(c.old, key)
+               item.Update({{.Args}})
+               c.current[key] = item
+       }
+
+       return c.current[key]
 }

--- a/ux/templates/gen.go
+++ b/ux/templates/gen.go
@@ -6,10 +6,13 @@
 package main
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"strings"
 	"text/template"
+	"golang.org/x/tools/imports"
+	"go/format"
 )
 
 func main() {
@@ -33,12 +36,21 @@ func main() {
 		panic(err)
 	}
 
-	out, err := os.Create(data["out"])
-	if err != nil {
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
 		panic(err)
 	}
 
-	if err := t.Execute(out, data); err != nil {
+	p, err := format.Source(buf.Bytes())
+	if  err != nil {
+		panic(err)
+	}
+	p, err = imports.Process("test.go", p, nil)
+	if err != nil {
+		panic(err)
+	}
+	err = ioutil.WriteFile(data["out"], p, os.ModePerm)
+	if err  != nil {
 		panic(err)
 	}
 }

--- a/ux/todo/task_edit_cache.go
+++ b/ux/todo/task_edit_cache.go
@@ -45,26 +45,6 @@ func (c *TaskEditCache) End() {
 	c.old = nil
 }
 
-
-// TryGet fetches a TaskEdit from the cache (updating it)
-// or creates a new TaskEdit
-//
-// It returns the TaskEdit but also whether the control existed.
-// This can be used to conditionally setup listeners.
-func (c *TaskEditCache) TryGet(key interface{}, styles core.Styles, task Task) (*TaskEdit, bool) {
-	exists := false
-	if item, ok := c.old[key]; !ok {
-		c.current[key] = NewTaskEdit(styles, task)
-	} else {
-		delete(c.old, key)
-		item.Update(styles, task)
-		c.current[key] = item
-		exists = true
-	}
-
-	return c.current[key], exists
-}
-
 // Item fetches the item at the specific key
 func (c *TaskEditCache) Item(key interface{}) *TaskEdit {
 	return c.current[key]
@@ -72,9 +52,14 @@ func (c *TaskEditCache) Item(key interface{}) *TaskEdit {
 
 // TaskEdit fetches a TaskEdit from the cache (updating it)
 // or creates a new TaskEdit
-//
-// Use TryGet to also fetch whether the control from last round was reused
 func (c *TaskEditCache) TaskEdit(key interface{}, styles core.Styles, task Task) *TaskEdit {
-	v, _ := c.TryGet(key, styles, task)
-        return v
+	if item, ok := c.old[key]; !ok {
+		c.current[key] = NewTaskEdit(styles, task)
+	} else {
+		delete(c.old, key)
+		item.Update(styles, task)
+		c.current[key] = item
+	}
+
+	return c.current[key]
 }

--- a/ux/todo/task_stream.go
+++ b/ux/todo/task_stream.go
@@ -8,7 +8,7 @@
 package todo
 
 import "github.com/dotchain/dot/changes"
-import	"github.com/dotchain/dot/ux/streams"
+import "github.com/dotchain/dot/ux/streams"
 
 // TaskStream holds a Task value and tracks changes to it.
 //

--- a/ux/todo/tasks_stream.go
+++ b/ux/todo/tasks_stream.go
@@ -8,7 +8,7 @@
 package todo
 
 import "github.com/dotchain/dot/changes"
-import	"github.com/dotchain/dot/ux/streams"
+import "github.com/dotchain/dot/ux/streams"
 
 // TasksStream holds a Tasks value and tracks changes to it.
 //

--- a/ux/todo/tasks_view_cache.go
+++ b/ux/todo/tasks_view_cache.go
@@ -45,26 +45,6 @@ func (c *TasksViewCache) End() {
 	c.old = nil
 }
 
-
-// TryGet fetches a TasksView from the cache (updating it)
-// or creates a new TasksView
-//
-// It returns the TasksView but also whether the control existed.
-// This can be used to conditionally setup listeners.
-func (c *TasksViewCache) TryGet(key interface{}, styles core.Styles, done bool, notDone bool, tasks Tasks) (*TasksView, bool) {
-	exists := false
-	if item, ok := c.old[key]; !ok {
-		c.current[key] = NewTasksView(styles, done, notDone, tasks)
-	} else {
-		delete(c.old, key)
-		item.Update(styles, done, notDone, tasks)
-		c.current[key] = item
-		exists = true
-	}
-
-	return c.current[key], exists
-}
-
 // Item fetches the item at the specific key
 func (c *TasksViewCache) Item(key interface{}) *TasksView {
 	return c.current[key]
@@ -72,9 +52,14 @@ func (c *TasksViewCache) Item(key interface{}) *TasksView {
 
 // TasksView fetches a TasksView from the cache (updating it)
 // or creates a new TasksView
-//
-// Use TryGet to also fetch whether the control from last round was reused
 func (c *TasksViewCache) TasksView(key interface{}, styles core.Styles, done bool, notDone bool, tasks Tasks) *TasksView {
-	v, _ := c.TryGet(key, styles, done, notDone, tasks)
-        return v
+	if item, ok := c.old[key]; !ok {
+		c.current[key] = NewTasksView(styles, done, notDone, tasks)
+	} else {
+		delete(c.old, key)
+		item.Update(styles, done, notDone, tasks)
+		c.current[key] = item
+	}
+
+	return c.current[key]
 }


### PR DESCRIPTION
This moves the less-functional version closer to the functional version in that the functional version just seems like it removes the boiler-plate and autogenerates it.