### PR TITLE
ux/fn: update TaskEdit with proper sub-stream reuse

### DIFF
--- a/ux/fn/checkbox_generated.go
+++ b/ux/fn/checkbox_generated.go
@@ -26,10 +26,7 @@ func (c *checkboxCtx) areArgsSame(styles core.Styles, checked *streams.BoolStrea
 	if styles != c.memoizedParams.styles {
 		return false
 	}
-	if checked != c.memoizedParams.checked {
-		return false
-	}
-	return true
+	return checked == c.memoizedParams.checked
 }
 
 func (c *checkboxCtx) refreshIfNeeded(styles core.Styles, checked *streams.BoolStream) (result1 core.Element) {

--- a/ux/fn/text_edit_generated.go
+++ b/ux/fn/text_edit_generated.go
@@ -26,10 +26,7 @@ func (c *textEditCtx) areArgsSame(styles core.Styles, text *streams.TextStream) 
 	if styles != c.memoizedParams.styles {
 		return false
 	}
-	if text != c.memoizedParams.text {
-		return false
-	}
-	return true
+	return text == c.memoizedParams.text
 }
 
 func (c *textEditCtx) refreshIfNeeded(styles core.Styles, text *streams.TextStream) (result1 core.Element) {

--- a/ux/fn/todo/task.go
+++ b/ux/fn/todo/task.go
@@ -23,8 +23,17 @@ type Task struct {
 //
 // codegen: pure
 func TaskEdit(c *taskEditCtx, styles core.Styles, task *TaskStream) core.Element {
-	done := streams.NewBoolStream(task.Value.Done)
-	text := streams.NewTextStream(task.Value.Description)
+	// the following sub-stream logic can probably be auto-generated
+	done := c.newBoolStream(task.Notifier, false).Latest()
+	if done.Value != task.Value.Done {
+		done = done.Update(nil, task.Value.Done)
+	}
+
+	// the following sub-stream logic can probably be auto-generated
+	text := c.newTextStream(task.Notifier, "").Latest()
+	if text.Value != task.Value.Description {
+		text = text.Update(nil, task.Value.Description)
+	}
 
 	onChange := func() {
 		task = task.Update(nil, Task{task.Value.ID, done.Value, text.Value})
@@ -39,6 +48,16 @@ func TaskEdit(c *taskEditCtx, styles core.Styles, task *TaskStream) core.Element
 		c.fn.Checkbox("cb", core.Styles{}, done),
 		c.fn.TextEdit("textedit", core.Styles{}, text),
 	)
+}
+
+// codegen: pure
+func newBoolStream(c *boolStreamCtx, v bool) *streams.BoolStream {
+	return streams.NewBoolStream(v)
+}
+
+// codegen: pure
+func newTextStream(c *textStreamCtx, v string) *streams.TextStream {
+	return streams.NewTextStream(v)
 }
 
 // generate TaskStream

--- a/ux/fn/todo/task_generated.go
+++ b/ux/fn/todo/task_generated.go
@@ -15,6 +15,8 @@ import (
 
 type taskEditCtx struct {
 	streams.Subs
+	newBoolStreamCache
+	newTextStreamCache
 	fn struct {
 		fn.CheckboxCache
 		fn.ElementCache
@@ -33,10 +35,7 @@ func (c *taskEditCtx) areArgsSame(styles core.Styles, task *TaskStream) bool {
 	if styles != c.memoizedParams.styles {
 		return false
 	}
-	if task != c.memoizedParams.task {
-		return false
-	}
-	return true
+	return task == c.memoizedParams.task
 }
 
 func (c *taskEditCtx) refreshIfNeeded(styles core.Styles, task *TaskStream) (result1 core.Element) {
@@ -51,6 +50,10 @@ func (c *taskEditCtx) refresh(styles core.Styles, task *TaskStream) (result1 cor
 	c.memoizedParams.styles, c.memoizedParams.task = styles, task
 	c.Subs.Begin()
 	defer c.Subs.End()
+	c.newBoolStreamCache.Begin()
+	defer c.newBoolStreamCache.End()
+	c.newTextStreamCache.Begin()
+	defer c.newTextStreamCache.End()
 	c.fn.CheckboxCache.Begin()
 	defer c.fn.CheckboxCache.End()
 	c.fn.ElementCache.Begin()
@@ -89,4 +92,116 @@ func (c *TaskEditCache) TaskEdit(key interface{}, styles core.Styles, task *Task
 	}
 	c.current[key] = cOld
 	return cOld.refreshIfNeeded(styles, task)
+}
+
+type boolStreamCtx struct {
+	memoInitialized bool
+	memoizedParams  struct {
+		v       bool
+		result1 *streams.BoolStream
+	}
+}
+
+func (c *boolStreamCtx) areArgsSame(v bool) bool {
+	return v == c.memoizedParams.v
+}
+
+func (c *boolStreamCtx) refreshIfNeeded(v bool) (result1 *streams.BoolStream) {
+	if !c.memoInitialized || !c.areArgsSame(v) {
+		return c.refresh(v)
+	}
+	return c.memoizedParams.result1
+}
+
+func (c *boolStreamCtx) refresh(v bool) (result1 *streams.BoolStream) {
+	c.memoInitialized = true
+	c.memoizedParams.v = v
+	c.memoizedParams.result1 = newBoolStream(c, v)
+	return c.memoizedParams.result1
+}
+
+// newBoolStreamCache is generated from newBoolStream.  Please see that for
+// documentation
+type newBoolStreamCache struct {
+	old, current map[interface{}]*boolStreamCtx
+}
+
+// Begin starts the round
+func (c *newBoolStreamCache) Begin() {
+	c.old, c.current = c.current, map[interface{}]*boolStreamCtx{}
+}
+
+// End ends the round
+func (c *newBoolStreamCache) End() {
+	// TODO: deliver Close() handlers if they exist
+	c.old = nil
+}
+
+// newBoolStream implements the cache create or fetch method
+func (c *newBoolStreamCache) newBoolStream(key interface{}, v bool) *streams.BoolStream {
+	cOld, ok := c.old[key]
+
+	if ok {
+		delete(c.old, key)
+	} else {
+		cOld = &boolStreamCtx{}
+	}
+	c.current[key] = cOld
+	return cOld.refreshIfNeeded(v)
+}
+
+type textStreamCtx struct {
+	memoInitialized bool
+	memoizedParams  struct {
+		v       string
+		result1 *streams.TextStream
+	}
+}
+
+func (c *textStreamCtx) areArgsSame(v string) bool {
+	return v == c.memoizedParams.v
+}
+
+func (c *textStreamCtx) refreshIfNeeded(v string) (result1 *streams.TextStream) {
+	if !c.memoInitialized || !c.areArgsSame(v) {
+		return c.refresh(v)
+	}
+	return c.memoizedParams.result1
+}
+
+func (c *textStreamCtx) refresh(v string) (result1 *streams.TextStream) {
+	c.memoInitialized = true
+	c.memoizedParams.v = v
+	c.memoizedParams.result1 = newTextStream(c, v)
+	return c.memoizedParams.result1
+}
+
+// newTextStreamCache is generated from newTextStream.  Please see that for
+// documentation
+type newTextStreamCache struct {
+	old, current map[interface{}]*textStreamCtx
+}
+
+// Begin starts the round
+func (c *newTextStreamCache) Begin() {
+	c.old, c.current = c.current, map[interface{}]*textStreamCtx{}
+}
+
+// End ends the round
+func (c *newTextStreamCache) End() {
+	// TODO: deliver Close() handlers if they exist
+	c.old = nil
+}
+
+// newTextStream implements the cache create or fetch method
+func (c *newTextStreamCache) newTextStream(key interface{}, v string) *streams.TextStream {
+	cOld, ok := c.old[key]
+
+	if ok {
+		delete(c.old, key)
+	} else {
+		cOld = &textStreamCtx{}
+	}
+	c.current[key] = cOld
+	return cOld.refreshIfNeeded(v)
 }

--- a/ux/fn/todo_generated.go
+++ b/ux/fn/todo_generated.go
@@ -40,10 +40,7 @@ func (c *tvCtx) areArgsSame(styles core.Styles, showDone bool, showNotDone bool,
 	if showNotDone != c.memoizedParams.showNotDone {
 		return false
 	}
-	if tasks != c.memoizedParams.tasks {
-		return false
-	}
-	return true
+	return tasks == c.memoizedParams.tasks
 }
 
 func (c *tvCtx) refreshIfNeeded(styles core.Styles, showDone bool, showNotDone bool, tasks *todo.TasksStream) (result1 core.Element) {


### PR DESCRIPTION
Demonstrates how sub-stream management is annoying.  This can be code-generated but can't seem to figure out a clean syntax for it.  One option is to do something like `c.substream.ParentStreamType.ChildStreamType(parent)`.