### PR TITLE
ux: simplify stateful components

### DIFF
--- a/compiler/generate.go
+++ b/compiler/generate.go
@@ -90,6 +90,11 @@ type ArgInfo struct {
 	IsLast     bool
 }
 
+// StateArgInfo has info about stateful args
+type StateArgInfo struct {
+	Name, Type, Ctor string
+}
+
 // ResultInfo has info about return values
 type ResultInfo struct {
 	Name, Type string
@@ -101,6 +106,7 @@ type ContextInfo struct {
 	Function      string
 	Subcomponents []string
 	Args          []ArgInfo
+	StateArgs     []StateArgInfo
 	Results       []ResultInfo
 	HasEllipsis   bool
 
@@ -130,11 +136,16 @@ func (c *ContextInfo) PkgSubcomps() interface{} {
 		}
 	}
 	add("", "initialized bool")
+	add("", "stateHandler streams.Handler")
 	for kk, arg := range c.Args {
 		if kk > 0 {
 			add("memoized", arg.Name+" "+arg.Type)
 		}
 	}
+	for _, arg := range c.StateArgs {
+		add("memoized", arg.Name+" "+arg.Type)
+	}
+
 	for kk, r := range c.Results {
 		n := r.Name
 		if n == "" {
@@ -195,6 +206,9 @@ func (c *ContextInfo) AllArgs() string {
 	result := []string{}
 	for _, a := range c.Args {
 		result = append(result, a.Name)
+	}
+	for _, a := range c.StateArgs {
+		result = append(result, c.Args[0].Name+".memoized."+a.Name)
 	}
 	return strings.Join(result, ", ")
 }

--- a/ux/fn/todo/codegen.go
+++ b/ux/fn/todo/codegen.go
@@ -85,12 +85,16 @@ func main() {
 			{
 				ContextType: "appCtx",
 
-				Function:      "App",
+				Function:      "AppWithState",
 				Subcomponents: []string{"TasksViewCache", "fn.ElementCache", "fn.CheckboxCache"},
 				Args: []compiler.ArgInfo{
 					{Name: "ctx", Type: "*appCtx"},
 					{Name: "styles", Type: "core.Styles"},
 					{Name: "tasks", Type: "*TasksStream", IsLast: true},
+				},
+				StateArgs: []compiler.StateArgInfo{
+					{Name: "showDone", Type: "*uxstreams.BoolStream", Ctor: "uxstreams.NewBoolStream(true)"},
+					{Name: "showNotDone", Type: "*uxstreams.BoolStream", Ctor: "uxstreams.NewBoolStream(true)"},
 				},
 				Results:     []compiler.ResultInfo{{Name: "", Type: "core.Element"}},
 				HasEllipsis: false,
@@ -99,7 +103,7 @@ func main() {
 				ComponentComments: "// AppCache is good",
 				Method:            "App",
 				MethodComments:    "// App is good",
-			},			
+			},
 		},
 	}
 	ioutil.WriteFile("generated.go", []byte(compiler.Generate(info)), 0644)

--- a/ux/fn/todo/todo.go
+++ b/ux/fn/todo/todo.go
@@ -59,13 +59,9 @@ func renderTasks(t Tasks, fn func(int, Task) core.Element) []core.Element {
 	return result
 }
 
-// App is a thin wrapper on top of TasksView with checkboxes for ShowDone and ShowUndone
+// AppWithState is a thin wrapper on top of TasksView with checkboxes for ShowDone and ShowUndone
 //
-// codegen: pure
-func App(c *appCtx, styles core.Styles, tasks *TasksStream) core.Element {
-	done := getAppStateStream(c, "done", styles, tasks)
-	notDone := getAppStateStream(c, "notDone", styles, tasks)
-
+func AppWithState(c *appCtx, styles core.Styles, tasks *TasksStream, done *streams.BoolStream, notDone *streams.BoolStream) core.Element {
 	return c.fn.Element(
 		"root",
 		core.Props{Tag: "div", Styles: styles},
@@ -73,20 +69,4 @@ func App(c *appCtx, styles core.Styles, tasks *TasksStream) core.Element {
 		c.fn.Checkbox("notDone", core.Styles{}, notDone),
 		c.TasksView("tasks", core.Styles{}, done, notDone, tasks),
 	)
-}
-
-func getAppStateStream(c *appCtx, name string, styles core.Styles, tasks *TasksStream) *streams.BoolStream {
-	var result *streams.BoolStream
-	var handler *streams.Handler
-	if f, h, ok := c.Cache.GetSubstream(nil, "done"); ok {
-		result, handler = f.(*streams.BoolStream), h
-	} else {
-		result = streams.NewBoolStream(true)
-		handler = &streams.Handler{nil}
-		result.On(handler)
-	}
-	handler.Handle = func() { c.refresh(styles, tasks) }
-	result = result.Latest()
-	c.Cache.SetSubstream(nil, name, result, handler, func() { result.Off(handler) })
-	return result
 }


### PR DESCRIPTION
Stateful components can simply take state as parameters.

This reads much better but:

- [ ] Need a way to disambiguate regular params from state params.  Maybe  use *State* suffix.
- [ ] Current code implicitly assumes stateful params are Stream types.  This is reasonable as the framework needs to add code to watch for changes.
- [ ] No clear syntax for declaring initial values for stateful components.

