### PR TITLE
ux: state is now an in+out parameter with no special ctor

### DIFF
--- a/ux/fn/todo/codegen.go
+++ b/ux/fn/todo/codegen.go
@@ -49,13 +49,12 @@ func main() {
 
 				Function:      "TaskEdit",
 				Subcomponents: []string{"fn.CheckboxCache", "fn.ElementCache", "fn.TextEditCache"},
-				Args: []compiler.ArgInfo{
+				Params: []compiler.ParamInfo{
 					{Name: "ctx", Type: "*taskEditCtx"},
 					{Name: "styles", Type: "core.Styles"},
-					{Name: "task", Type: "*TaskStream", IsLast: true},
+					{Name: "task", Type: "*TaskStream"},
 				},
-				Results:     []compiler.ResultInfo{{Name: "", Type: "core.Element"}},
-				HasEllipsis: false,
+				Results: []compiler.ResultInfo{{Name: "", Type: "core.Element"}},
 
 				Component:         "TaskEditCache",
 				ComponentComments: "// TaskEditCache is good",
@@ -67,15 +66,14 @@ func main() {
 
 				Function:      "TasksView",
 				Subcomponents: []string{"TaskEditCache", "fn.ElementCache"},
-				Args: []compiler.ArgInfo{
+				Params: []compiler.ParamInfo{
 					{Name: "ctx", Type: "*tasksViewCtx"},
 					{Name: "styles", Type: "core.Styles"},
 					{Name: "showDone", Type: "*uxstreams.BoolStream"},
 					{Name: "showNotDone", Type: "*uxstreams.BoolStream"},
-					{Name: "tasks", Type: "*TasksStream", IsLast: true},
+					{Name: "tasks", Type: "*TasksStream"},
 				},
-				Results:     []compiler.ResultInfo{{Name: "", Type: "core.Element"}},
-				HasEllipsis: false,
+				Results: []compiler.ResultInfo{{Name: "", Type: "core.Element"}},
 
 				Component:         "TasksViewCache",
 				ComponentComments: "// TasksViewCache is good",
@@ -85,19 +83,20 @@ func main() {
 			{
 				ContextType: "appCtx",
 
-				Function:      "AppWithState",
+				Function:      "App",
 				Subcomponents: []string{"TasksViewCache", "fn.ElementCache", "fn.CheckboxCache"},
-				Args: []compiler.ArgInfo{
-					{Name: "ctx", Type: "*appCtx"},
-					{Name: "styles", Type: "core.Styles"},
-					{Name: "tasks", Type: "*TasksStream", IsLast: true},
+				Params: []compiler.ParamInfo{
+					{"ctx", "*appCtx"},
+					{"styles", "core.Styles"},
+					{"tasks", "*TasksStream"},
+					{"doneState", "*uxstreams.BoolStream"},
+					{"notDoneState", "*uxstreams.BoolStream"},
 				},
-				StateArgs: []compiler.StateArgInfo{
-					{Name: "showDone", Type: "*uxstreams.BoolStream", Ctor: "uxstreams.NewBoolStream(true)"},
-					{Name: "showNotDone", Type: "*uxstreams.BoolStream", Ctor: "uxstreams.NewBoolStream(true)"},
+				Results: []compiler.ResultInfo{
+					{"", "core.Element"},
+					{"", "*uxstreams.BoolStream"},
+					{"", "*uxstreams.BoolStream"},
 				},
-				Results:     []compiler.ResultInfo{{Name: "", Type: "core.Element"}},
-				HasEllipsis: false,
 
 				Component:         "AppCache",
 				ComponentComments: "// AppCache is good",

--- a/ux/fn/todo/todo.go
+++ b/ux/fn/todo/todo.go
@@ -59,14 +59,21 @@ func renderTasks(t Tasks, fn func(int, Task) core.Element) []core.Element {
 	return result
 }
 
-// AppWithState is a thin wrapper on top of TasksView with checkboxes for ShowDone and ShowUndone
+// App is a thin wrapper on top of TasksView with checkboxes for ShowDone and ShowUndone
 //
-func AppWithState(c *appCtx, styles core.Styles, tasks *TasksStream, done *streams.BoolStream, notDone *streams.BoolStream) core.Element {
+func App(c *appCtx, styles core.Styles, tasks *TasksStream, doneState *streams.BoolStream, notDoneState *streams.BoolStream) (core.Element, *streams.BoolStream, *streams.BoolStream) {
+	if doneState == nil {
+		doneState = streams.NewBoolStream(true)
+	}
+	if notDoneState == nil {
+		notDoneState = streams.NewBoolStream(true)
+	}
+
 	return c.fn.Element(
 		"root",
 		core.Props{Tag: "div", Styles: styles},
-		c.fn.Checkbox("done", core.Styles{}, done),
-		c.fn.Checkbox("notDone", core.Styles{}, notDone),
-		c.TasksView("tasks", core.Styles{}, done, notDone, tasks),
-	)
+		c.fn.Checkbox("done", core.Styles{}, doneState),
+		c.fn.Checkbox("notDone", core.Styles{}, notDoneState),
+		c.TasksView("tasks", core.Styles{}, doneState, notDoneState, tasks),
+	), doneState, notDoneState
 }


### PR DESCRIPTION
This allows a stateful component to simply just  do:

```golang
func statefulComponent(c *myCtx, xState *XStream, yState *YStream, regular args...) (*XStream, *YStream, ... regular results) {
       if xState == nil {
          ... initialize
       }
       if yState == nil {
           ... initialize
       }
        ....
       return xState, yState, ...
}
```

This now solves the custom initialization problem.  Callers of this component simply do  not see the state param or the state return values.