### PR TITLE
dot/streams: change substream to return nil on termination

### DIFF
--- a/streams/substream.go
+++ b/streams/substream.go
@@ -41,7 +41,7 @@ type substream struct {
 
 func (s *substream) Next() (Stream, changes.Change) {
 	if s.ref == refs.InvalidRef {
-		return s, nil
+		return nil, nil
 	}
 
 	next, nextc := s.parent.Next()

--- a/streams/substream_test.go
+++ b/streams/substream_test.go
@@ -91,7 +91,7 @@ func (s subsuite) InvalidRef(t *testing.T) {
 	}
 
 	nn2, cc2 := nn.Next()
-	if nn2 != nn || cc2 != nil {
+	if nn2 != nil || cc2 != nil {
 		t.Error("Invalid ref didn't do its thing", nn2, cc2)
 	}
 


### PR DESCRIPTION
This behavior makes more sense: a terminated stream acts just like a stream that never gets any more changes.  It  also ensures that a Latest() call will not enter an infinite loop.