### PR TITLE
dot/stress: add initial stress app

### DIFF
--- a/server.go
+++ b/server.go
@@ -16,7 +16,7 @@ import (
 
 // BoltServer returns a http.Handler serving DOT requests backed by the db
 func BoltServer(fileName string) http.Handler {
-	store, err := bolt.New("file.bolt", "dot_root", nil)
+	store, err := bolt.New(fileName, "dot_root", nil)
 	must(err)
 	store = nw.MemPoller(store)
 	return &nw.Handler{Store: store}

--- a/stress/codegen.go
+++ b/stress/codegen.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+//+build ignore
+
+package main
+
+import (
+	"io/ioutil"
+
+	"github.com/dotchain/dot/x/dotc"
+)
+
+func main() {
+	code, err := info.Generate()
+	if err != nil {
+		panic(err)
+	}
+	code = "//+build stress\n\n" + code
+	err = ioutil.WriteFile("generated_test.go", []byte(code), 0644)
+	if err != nil {
+		panic(err)
+	}
+}
+
+var info = dotc.Info{
+	Package: "stress_test",
+	Structs: []dotc.Struct{{
+		Recv: "s",
+		Type: "State",
+		Fields: []dotc.Field{{
+			Name:               "Text",
+			Key:                "text",
+			Type:               "string",
+			ToValueFmt:         "types.S8(%s)%.s",
+			FromValueFmt:       "string(%s.(types.S8))%.s",
+			FromStreamValueFmt: "%s%.s",
+			ToStreamFmt:        "streams.S8%.s",
+		}, {
+			Name:               "Count",
+			Key:                "count",
+			Type:               "types.Counter",
+			ToValueFmt:         "%s%.s",
+			FromValueFmt:       "%s.(types.Counter)%.s",
+			FromStreamValueFmt: "int32(%s)%.s",
+			ToStreamFmt:        "streams.Counter%.s",
+		}},
+	}},
+}

--- a/stress/generated_test.go
+++ b/stress/generated_test.go
@@ -1,0 +1,95 @@
+//+build stress
+
+// Generated.  DO NOT EDIT.
+package stress_test
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+	"github.com/dotchain/dot/streams"
+)
+
+func (s State) get(key interface{}) changes.Value {
+	switch key {
+
+	case "text":
+		return types.S8(s.Text)
+	case "count":
+		return s.Count
+	}
+	panic(key)
+}
+
+func (s State) set(key interface{}, v changes.Value) changes.Value {
+	sClone := s
+	switch key {
+	case "text":
+		sClone.Text = string(v.(types.S8))
+	case "count":
+		sClone.Count = v.(types.Counter)
+	}
+	return sClone
+}
+
+func (s State) Apply(ctx changes.Context, c changes.Change) changes.Value {
+	return (types.Generic{Get: s.get, Set: s.set}).Apply(ctx, c, s)
+}
+
+func (s State) SetText(value string) State {
+	sReplace := changes.Replace{types.S8(s.Text), types.S8(value)}
+	sChange := changes.PathChange{[]interface{}{"text"}, sReplace}
+	return s.Apply(nil, sChange).(State)
+}
+
+func (s State) SetCount(value types.Counter) State {
+	sReplace := changes.Replace{s.Count, value}
+	sChange := changes.PathChange{[]interface{}{"count"}, sReplace}
+	return s.Apply(nil, sChange).(State)
+}
+
+// StateStream implements a stream of State values
+type StateStream struct {
+	Stream streams.Stream
+	Value  State
+}
+
+// Next returns the next entry in the stream if there is one
+func (s *StateStream) Next() (*StateStream, changes.Change) {
+	if s.Stream == nil {
+		return nil, nil
+	}
+
+	next, nextc := s.Stream.Next()
+	if next == nil {
+		return nil, nil
+	}
+
+	if nextVal, ok := s.Value.Apply(nil, nextc).(State); ok {
+		return &StateStream{Stream: next, Value: nextVal}, nextc
+	}
+	return &StateStream{Value: s.Value}, nil
+}
+
+// Latest returns the latest entry in the stream
+func (s *StateStream) Latest() *StateStream {
+	for n, _ := s.Next(); n != nil; n, _ = s.Next() {
+		s = n
+	}
+	return s
+}
+
+// Update replaces the current value with the new value
+func (s *StateStream) Update(val State) *StateStream {
+	if s.Stream != nil {
+		nexts := s.Stream.Append(changes.Replace{Before: s.Value, After: val})
+		s = &StateStream{Stream: nexts, Value: val}
+	}
+	return s
+}
+
+func (s *StateStream) Text() *streams.S8 {
+	return &streams.S8{Stream: streams.Substream(s.Stream, "text"), Value: s.Value.Text}
+}
+func (s *StateStream) Count() *streams.Counter {
+	return &streams.Counter{Stream: streams.Substream(s.Stream, "count"), Value: int32(s.Value.Count)}
+}

--- a/stress/state_test.go
+++ b/stress/state_test.go
@@ -1,0 +1,95 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+//+build stress
+
+package stress_test
+
+//go:generate go run codegen.go
+
+import (
+	"encoding/gob"
+	"log"
+	"math/rand"
+	"sync"
+
+	"github.com/dotchain/dot/changes/types"
+	"github.com/dotchain/dot/streams"
+)
+
+type State struct {
+	Text  string
+	Count types.Counter
+}
+
+func rounds(clients []*StateStream, iterations, rounds int) {
+	var wg sync.WaitGroup
+	var waitCount int
+
+	for jj := 0; jj < rounds; jj++ {
+		wg.Add(len(clients))
+		waitCount += len(clients)
+		for kk, client := range clients {
+			round(kk, client, iterations, waitCount, &wg)
+			clients[kk] = client.Latest()
+		}
+		wg.Wait()
+		log.Println("finished round", jj)
+	}
+}
+
+func round(idx int, s *StateStream, iterations, waitCount int, wait *sync.WaitGroup) {
+	go func() {
+		modifyTextRandomly(idx, s.Text(), iterations)
+		s = s.Latest()
+		counter := s.Count()
+		counter.Increment(1)
+
+		finished := false
+		counter.Stream.Nextf(idx, func() {
+			s = s.Latest()
+			if !finished && int32(s.Value.Count) >= int32(waitCount) {
+				finished = true
+				counter.Stream.Nextf(idx, nil)
+				wait.Done()
+			}
+		})
+	}()
+}
+
+func modifyTextRandomly(idx int, s *streams.S8, iterations int) {
+	for kk := 0; kk < iterations; kk++ {
+		s = s.Latest()
+		l := len(s.Value)
+		insert := randString(3)
+
+		if l == 0 {
+			s = s.Splice(0, 0, insert)
+		} else {
+			var offset, count int
+			if l > 0 {
+				offset = rand.Intn(l)
+			}
+			if l-offset > 0 {
+				count = rand.Intn(l - offset)
+			}
+			s = s.Splice(offset, count, insert)
+		}
+	}
+}
+
+var letters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func init() {
+	gob.Register(State{})
+	rand.Seed(42)
+}

--- a/stress/stress_test.go
+++ b/stress/stress_test.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+//+build stress
+
+package stress_test
+
+//go:generate go run codegen.go
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dotchain/dot"
+	"github.com/dotchain/dot/changes/types"
+)
+
+func Server() {
+	// uses a local-file backed bolt DB backend
+	http.Handle("/stress/", dot.BoltServer("stress.bolt"))
+	http.ListenAndServe(":8083", nil)
+}
+
+func Client() {
+	streams := make([]*StateStream, 4)
+	sessions := make([]*dot.Session, 4)
+	initial := State{Text: "hello world", Count: types.Counter(0)}
+	for kk := range streams {
+		session, str := dot.Connect("http://localhost:8083/stress/")
+		sessions[kk] = session
+		streams[kk] = &StateStream{Stream: str, Value: initial}
+	}
+	rounds(streams, 5, 100)
+}
+
+func TestStress(t *testing.T) {
+	if err := os.Remove("stress.bolt"); err != nil {
+		log.Println("Didnt remove stress.bolt file", err)
+	}
+
+	go Server()
+	time.Sleep(time.Second * 2)
+	Client()
+	if err := os.Remove("stress.bolt"); err != nil {
+		log.Println("Didnt remove stress.bolt file", err)
+	}
+}

--- a/x/dotc/field.go
+++ b/x/dotc/field.go
@@ -77,7 +77,7 @@ func (f Field) FromValue(recv, field string) string {
 	if field != "" {
 		key += "." + field
 	}
-	return f.format(key, f.ToValueFmt, fromValueFormats)
+	return f.format(key, f.FromValueFmt, fromValueFormats)
 }
 
 // FromStreamValue returns the name of the associated stream type


### PR DESCRIPTION
The stress app can be run by doing `go test --tags=stress`.

The stress app seems to succeed and only runs a few seconds and does not include all possible operations and types.

But it is a decent start.