### PR TITLE
stress: fix bad state issue with reconnect

### DIFF
--- a/stress/stress.go
+++ b/stress/stress.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"net/http"
 	"sync"
-	"time"
 
 	"github.com/dotchain/dot"
 )
@@ -62,11 +61,6 @@ func Run(oldStates []SessionState, rounds, iterations, clients int) []SessionSta
 		log.Println("Finished round", rr+1)
 	}
 
-	// TODO: remove time.Sleep
-	// This sleep is there to prevent crashes
-	// Looks like termination of a session is not quite clean
-
-	time.Sleep(time.Second)
 	states := make([]SessionState, len(sessions))
 	for kk := range sessions {
 		states[kk] = sessions[kk].Close()


### PR DESCRIPTION
Stress tests for the win.

Removing the time.Sleep because of a combination of bad-cleanup (pending entries were not always flushed) and bad-restart (fake pending entries were not added).

Its a bit lame that the ops/ tests do not catch either issue.  Need to rethink those test or atleast patch them up for these cases.

Also, it took me several hours to track this issue down.  Probably because unit tests caught all issues, never had to build out the right logging infrastructure to debug this.  Need to think about how to debug this.