### PR TITLE
cleanup interop tests to match dotchain/dataset repo

### DIFF
--- a/changes/correctness_test.go
+++ b/changes/correctness_test.go
@@ -11,22 +11,6 @@ import (
 	"github.com/dotchain/dot/test/seqtest"
 )
 
-// These sequences are a bit odd to start with, so the specific
-// outcomes are probably ok.  Should just rewrite the dataset for
-// this. Most of these seem like a problem with splices adjacent to
-// the move wrongly moving along with the move.
-var knownFailures = map[string]string{
-	"-abc[123]de4|56fg- x -abc1|23de[456]fg-": "-abcde145623fg-",
-	"-abc123[|d]456f- x -abc123[456]f|-":      "-abc123fd456-",
-	"-abc123[|d]456f- x -abc|123[456]f-":      "-abcd456123f-",
-	"-abc123[|d]456f- x -ab|c123[456]f-":      "-abd456c123f-",
-	"-ab|c[123]ef- x -abc123[|d]ef-":          "-ab123dcef-",
-	"-abc[123]e|f- x -abc123[|d]ef-":          "-abce123df-",
-	"-abc[1234|d]ef- x -ab|c[1234]ef-":        "-ab1234cdef-",
-	"-abc[1234|]ef- x -ab|c[1234]ef-":         "-ab1234cef-",
-	"-abc[|d]ef- x -a|b[ce]f-":                "-acdebf-",
-}
-
 func TestCorrectnessOfStandardSequences(t *testing.T) {
 	s := seqTester{}
 	seqtest.ForEachTest(s, s, func(name, initial string, l, r interface{}, merged string) {
@@ -43,8 +27,8 @@ func TestCorrectnessOfStandardSequences(t *testing.T) {
 				t.Error("Diverged", lval, rval, left, right)
 			}
 
-			if lval != S(merged) && lval != S(knownFailures[name]) {
-				t.Error("Converged on unexpected value", lval, merged, knownFailures[name])
+			if lval != S(merged) {
+				t.Error("Converged on unexpected value", lval, merged)
 			}
 		})
 	})

--- a/changes/path.go
+++ b/changes/path.go
@@ -46,7 +46,7 @@ func (pc PathChange) ApplyTo(ctx Context, v Value) Value {
 	if len(pc.Path) == 0 {
 		return v.Apply(ctx, pc.Change)
 	}
-	panic("Unexpected use of PathChange.ApplyTo")
+	panic("unexpected use of PathChange.ApplyTo")
 }
 
 func (pc PathChange) mergePathChange(o PathChange, reverse bool) (Change, Change) {

--- a/changes/splice.go
+++ b/changes/splice.go
@@ -42,9 +42,12 @@ func (s Splice) MergeSplice(other Splice) (other1, s1 *Splice) {
 		s.Before = s.Before.Slice(0, ostart-sstart)
 		return &other, &s
 
-	case sstart == ostart && send < oend: // [<  ]   >
-		other.Before = other.Before.ApplyCollection(nil, Splice{0, s.Before, s.After})
-		return &other, nil
+	case sstart == ostart && send < oend: // <[  ]   >
+		other.Before = other.Before.Slice(s.Before.Count(), other.Before.Count()-s.Before.Count())
+		other.Offset += s.After.Count()
+
+		s.Before = s.Before.Slice(0, 0)
+		return &other, &s
 
 	case sstart <= ostart && send >= oend: // [ < > ]
 		sliced := s.Before.Slice(ostart-sstart, oend-ostart)

--- a/test/seqtest/seqtest.go
+++ b/test/seqtest/seqtest.go
@@ -137,7 +137,7 @@ var sequenceTests = [][3]string{
 	{"-abc[123|d]4fgh-", "-abc12[34|e]fgh-", "-abcdefgh-"},
 	{"-abc[123|]4fgh-", "-abc12[34|e]fgh-", "-abcefgh-"},
 
-	{"-abc[123|d]4fgh-", "-abc[1234|e]fgh-", "-abcefgh-"},
+	{"-abc[123|d]4fgh-", "-abc[1234|e]fgh-", "-abcdefgh-"},
 	{"-abc[123|]4fgh-", "-abc[1234|e]fgh-", "-abcefgh-"},
 
 	{"-abc12[34|d]fgh-", "-abc[123|e]4fgh-", "-abcedfgh-"},
@@ -147,7 +147,7 @@ var sequenceTests = [][3]string{
 	{"-abc12[34|e]fgh-", "-abc[1234|d]fgh-", "-abcdfgh-"},
 
 	{"-abc[1234|d]fgh-", "-abc[12|e]34fgh-", "-abcdfgh-"},
-	{"-abc[12|e]34fgh-", "-abc[1234|d]fgh-", "-abcdfgh-"},
+	{"-abc[12|e]34fgh-", "-abc[1234|d]fgh-", "-abcedfgh-"},
 
 	{"-abc[1234|d]fgh-", "-abc1[23|e]4fgh-", "-abcdfgh-"},
 	{"-abc1[23|e]4fgh-", "-abc[1234|d]fgh-", "-abcdfgh-"},
@@ -171,7 +171,7 @@ var sequenceTests = [][3]string{
 	{"-abc[123]de456f|g-", "-abc123de[456]fg|-", "-abcdef123g456-"},
 
 	// conflicting move move tests
-	{"-abc[123]de4|56fg-", "-abc1|23de[456]fg-", "-abc456de123fg-"},
+	{"-abc[123]de4|56fg-", "-abc1|23de[456]fg-", "-abcde145623fg-"},
 
 	// Series D: non-conflicting splice vs move
 	{"-abc[123|d]e456f-", "-abc123|e[456]f-", "-abcd456ef-"},
@@ -193,9 +193,9 @@ var sequenceTests = [][3]string{
 	{"-abc[123|]456f-", "-abc123[456]f|-", "-abcf456-"},
 	{"-abc[123|]456f-", "-abc|123[456]f-", "-abc456f-"},
 	{"-abc[123|]456f-", "-ab|c123[456]f-", "-ab456cf-"},
-	{"-abc123[|d]456f-", "-abc123[456]f|-", "-abc123df456-"},
-	{"-abc123[|d]456f-", "-abc|123[456]f-", "-abc456123df-"},
-	{"-abc123[|d]456f-", "-ab|c123[456]f-", "-ab456c123df-"},
+	{"-abc123[|d]456f-", "-abc123[456]f|-", "-abc123fd456-"},
+	{"-abc123[|d]456f-", "-abc|123[456]f-", "-abcd456123f-"},
+	{"-abc123[|d]456f-", "-ab|c123[456]f-", "-abd456c123f-"},
 
 	// Series E: non-conflicting move vs splice
 	{"-ab|c[123]de456gh-", "-abc123de[456|f]gh-", "-ab123cdefgh-"},
@@ -223,17 +223,17 @@ var sequenceTests = [][3]string{
 	{"-abc[123]456|ef-", "-abc123[456|]ef-", "-abc123ef-"},
 	{"-abc[123]456e|f-", "-abc123[456|]ef-", "-abce123f-"},
 
-	{"-ab|c[123]ef-", "-abc123[|d]ef-", "-ab123cdef-"},
-	{"-abc[123]e|f-", "-abc123[|d]ef-", "-abcde123f-"},
+	{"-ab|c[123]ef-", "-abc123[|d]ef-", "-ab123dcef-"},
+	{"-abc[123]e|f-", "-abc123[|d]ef-", "-abce123df-"},
 
 	// Series F: Splices conflicting with moves.
 	// Note a very large number of cases here are testable but the actual
 	// results of these operations are not interesting so long as there is "convergence"
 	// so the only real test being done is when one range fully contains the other.
 	{"-abc[1234|d]ef-", "-abc[12]3|4ef-", "-abcdef-"},
-	{"-abc[1234|d]ef-", "-ab|c[1234]ef-", "-abdcef-"},
-	{"-abc[1234|]ef-", "-ab|c[1234]ef-", "-abcef-"},
-	{"-abc[|d]ef-", "-a|b[ce]f-", "-acebdf-"}, // this is odd but ok
+	{"-abc[1234|d]ef-", "-ab|c[1234]ef-", "-ab1234cdef-"},
+	{"-abc[1234|]ef-", "-ab|c[1234]ef-", "-ab1234cef-"},
+	{"-abc[|d]ef-", "-a|b[ce]f-", "-acdebf-"},
 	{"-abc[|d]ef-", "-ab|c[]ef-", "-abcdef-"},
 	{"-ab|c[1234]ef-", "-abc1[23|d]4ef-", "-ab1d4cef-"},
 

--- a/x/fold/example_test.go
+++ b/x/fold/example_test.go
@@ -63,7 +63,7 @@ func Example_nilFold() {
 	defer upstream.Nextf("mykey", nil)
 
 	folded := fold.New(changes.Splice{Offset: 0, Before: types.S8(""), After: types.S8("hello")}, upstream)
-	folded2 := folded.Append(changes.Splice{Offset: 0, Before: types.S8("j"), After: types.S8("j")})
+	folded2 := folded.Append(changes.Splice{Offset: 1, Before: types.S8("e"), After: types.S8("u")})
 	folded.Append(changes.Splice{Offset: 10, Before: types.S8(""), After: types.S8("insert")})
 	c, _ := fold.Unfold(folded2)
 
@@ -71,7 +71,7 @@ func Example_nilFold() {
 
 	// Output:
 	// Got Change: {5  insert}
-	// Unfolded: {0  jello}
+	// Unfolded: {0  hullo}
 }
 
 func Example_nextf() {


### PR DESCRIPTION
The changes to merge are minimal and make it actually a little better in some odd cases.

This allows both the JS and Go version to be in sync better by comparinng against the master json tests.

The dotchain/dataset repo has been updated as well.

For all practical purposes, the merge behavior will likely be frozen onces the JS implementation conforms to the same set which is likely very soon.