### PR TITLE
Add fred: a functional reactive engine

### DIFF
--- a/fred/dir.go
+++ b/fred/dir.go
@@ -1,0 +1,97 @@
+// Copyright (C) 2018 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package fred
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+	"github.com/dotchain/dot/streams"
+)
+
+// Dir the main fred container which holds all objects.
+type Dir map[string]Object
+
+func (d Dir) set(key interface{}, value changes.Value) changes.Value {
+	clone := Dir{}
+	for k, v := range d {
+		if k != key {
+			clone[k] = v
+		}
+	}
+
+	if value != changes.Nil {
+		clone[key.(string)] = value.(Object)
+	}
+	return clone
+}
+
+func (d Dir) get(key interface{}) changes.Value {
+	if v, ok := d[key.(string)]; ok {
+		return v
+	}
+	return changes.Nil
+}
+
+// Apply implements the changes.Value interface
+func (d Dir) Apply(ctx changes.Context, c changes.Change) changes.Value {
+	return (types.Generic{Set: d.set, Get: d.get}).Apply(ctx, c, d)
+}
+
+// NewDirStream returns a new dir stream. The second arg is optional
+func NewDirStream(dir Dir, s streams.Stream) *DirStream {
+	if s == nil {
+		s = streams.New()
+	}
+	return &DirStream{
+		Value:   dir,
+		Stream:  s,
+		Cache:   map[interface{}]Object{},
+		Changes: map[interface{}]changes.Change{},
+	}
+}
+
+// DirStream implements a stream of dir versions
+type DirStream struct {
+	Value  Dir
+	Stream streams.Stream
+
+	// the following are really performance optimizations
+	next    *DirStream
+	Cache   map[interface{}]Object
+	Changes map[interface{}]changes.Change
+}
+
+func (s *DirStream) Next() (*DirStream, changes.Change) {
+	if s.Stream != nil {
+		next, c := s.Stream.Next()
+		if next != nil && s.next == nil {
+			s.next = NewDirStream(s.Value.Apply(nil, c).(Dir), next)
+		}
+		return s.next, c
+	}
+	return nil, nil
+}
+
+func (s *DirStream) Eval(obj Object) (Object, *ObjectStream) {
+	result := &ObjectStream{s, obj}
+	return result.Eval(), result
+}
+
+type ObjectStream struct {
+	*DirStream
+	Object
+}
+
+func (s *ObjectStream) Next() (*ObjectStream, changes.Change) {
+	if next, c := s.DirStream.Next(); next != nil {
+		nx, cx := s.Object.Next(s.DirStream, next, c)
+		return &ObjectStream{next, nx}, cx
+	}
+	return nil, nil
+}
+
+func (s *ObjectStream) Eval() Object {
+	return s.Object.Eval(s.DirStream)
+}

--- a/fred/error.go
+++ b/fred/error.go
@@ -2,28 +2,21 @@
 // Use of this source code is governed by a MIT-style license
 // that can be found in the LICENSE file.
 
-// Package fred implements a convergent functional reactive engine.
-//
-// It uses a pull-based functional reactive system (instead of push
-// based setup) to make it easy to only rebuild the parts of the graph
-// needed.
-//
-// The main entrypoint is Dir which maintains a directory of object
-// defintions.  Objects are indexed by an ID (string) and values can
-// be fixed or derived.  Fixed values evaluate to themselves while
-// derived values evaluate to a different result.
 package fred
 
 import (
 	"github.com/dotchain/dot/changes"
 )
 
+// Error represents an error string
 type Error string
 
+// Error satisfies the error interface
 func (e Error) Error() string {
 	return string(e)
 }
 
+// Apply implements changes.Value
 func (e Error) Apply(ctx changes.Context, c changes.Change) changes.Value {
 	if c == nil {
 		return e
@@ -34,10 +27,12 @@ func (e Error) Apply(ctx changes.Context, c changes.Change) changes.Value {
 	return c.(changes.Custom).ApplyTo(ctx, e)
 }
 
+// Eval evaluates to itself
 func (e Error) Eval(_ *DirStream) Object {
 	return e
 }
 
-func (e Error) Next(old, next *DirStream, c changes.Change) (Object, changes.Change) {
-	return e, nil
+// Diff returns any changes between old and new
+func (e Error) Diff(old, next *DirStream, c changes.Change) changes.Change {
+	return nil
 }

--- a/fred/error.go
+++ b/fred/error.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+// Package fred implements a convergent functional reactive engine.
+//
+// It uses a pull-based functional reactive system (instead of push
+// based setup) to make it easy to only rebuild the parts of the graph
+// needed.
+//
+// The main entrypoint is Dir which maintains a directory of object
+// defintions.  Objects are indexed by an ID (string) and values can
+// be fixed or derived.  Fixed values evaluate to themselves while
+// derived values evaluate to a different result.
+package fred
+
+import (
+	"github.com/dotchain/dot/changes"
+)
+
+type Error string
+
+func (e Error) Error() string {
+	return string(e)
+}
+
+func (e Error) Apply(ctx changes.Context, c changes.Change) changes.Value {
+	if c == nil {
+		return e
+	}
+	if replace, ok := c.(changes.Replace); ok {
+		return replace.After
+	}
+	return c.(changes.Custom).ApplyTo(ctx, e)
+}
+
+func (e Error) Eval(_ *DirStream) Object {
+	return e
+}
+
+func (e Error) Next(old, next *DirStream, c changes.Change) (Object, changes.Change) {
+	return e, nil
+}

--- a/fred/fred.go
+++ b/fred/fred.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+// Package fred implements a convergent functional reactive engine.
+//
+// It uses a pull-based functional reactive system (instead of push
+// based setup) to make it easy to only rebuild the parts of the graph
+// needed.
+//
+// The main entrypoint is Dir which maintains a directory of object
+// defintions.  Objects are indexed by an ID (string) and values can
+// be fixed or derived.  Fixed values evaluate to themselves while
+// derived values evaluate to a different result.
+package fred
+
+import (
+	"github.com/dotchain/dot/changes"
+)
+
+// Object is the required interface for all objects in fred
+type Object interface {
+	changes.Value
+	Eval(*DirStream) Object
+	Next(old, next *DirStream, c changes.Change) (Object, changes.Change)
+}
+
+func replace(before, after changes.Value) changes.Change {
+	if before == after {
+		return nil
+	}
+	return changes.Replace{Before: before, After: after}
+}

--- a/fred/fred.go
+++ b/fred/fred.go
@@ -22,7 +22,7 @@ import (
 type Object interface {
 	changes.Value
 	Eval(*DirStream) Object
-	Next(old, next *DirStream, c changes.Change) (Object, changes.Change)
+	Diff(old, next *DirStream, c changes.Change) changes.Change
 }
 
 func replace(before, after changes.Value) changes.Change {

--- a/fred/fred_test.go
+++ b/fred/fred_test.go
@@ -1,0 +1,119 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package fred_test
+
+import (
+	"fmt"
+
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/fred"
+)
+
+func ExampleDir_basic() {
+	dir := fred.Dir{
+		"heya": fred.Error("custom error"),
+		"suya": fred.Error("suya is suya"),
+		"ptr":  fred.Ref("heya"),
+	}
+	s := fred.NewDirStream(dir, nil)
+	ptr, s1 := s.Eval(fred.Ref("heya"))
+	ptr2, s2 := s.Eval(fred.Ref("ptr"))
+	fmt.Println("Got", ptr, ptr2)
+
+	// Now replace heya with heya2 and ptr from &heya to &suya
+	s.Stream.Append(changes.ChangeSet{
+		changes.PathChange{
+			Path: []interface{}{"heya"},
+			Change: changes.Replace{
+				Before: fred.Error("custom error"),
+				After:  fred.Error("new error"),
+			},
+		},
+		changes.PathChange{
+			Path: []interface{}{"ptr"},
+			Change: changes.Replace{
+				Before: fred.Ref("heya"),
+				After:  fred.Ref("suya"),
+			},
+		},
+	})
+
+	s1x, c1 := s1.Next()
+	s2x, c2 := s2.Next()
+
+	ptr = s1x.Eval()
+	ptr2 = s2x.Eval()
+
+	fmt.Println("Got", ptr, ptr2)
+	fmt.Println("Changes", c1, c2)
+
+	// Output:
+	// Got custom error custom error
+	// Got new error suya is suya
+	// Changes {custom error new error} {custom error suya is suya}
+}
+
+func ExampleDir_addNewRef() {
+	dir := fred.Dir{
+		"heya": fred.Error("custom error"),
+		"suya": fred.Error("suya is suya"),
+		"ptr":  fred.Ref("heya"),
+	}
+	s := fred.NewDirStream(dir, nil)
+	ptr, s1 := s.Eval(fred.Ref("heya"))
+	ptr2, s2 := s.Eval(fred.Ref("ptr"))
+	fmt.Println("Got", ptr, ptr2)
+
+	// Now replace heya with heya2 and ptr from &heya to &suya
+	s.Stream.Append(changes.ChangeSet{
+		changes.PathChange{
+			Path: []interface{}{"oomi"},
+			Change: changes.Replace{
+				Before: changes.Nil,
+				After:  fred.Error("gumi"),
+			},
+		},
+		changes.PathChange{
+			Path: []interface{}{"ptr"},
+			Change: changes.Replace{
+				Before: fred.Ref("heya"),
+				After:  fred.Ref("oomi"),
+			},
+		},
+	})
+
+	s1x, c1 := s1.Next()
+	s2x, c2 := s2.Next()
+
+	ptr = s1x.Eval()
+	ptr2 = s2x.Eval()
+
+	fmt.Println("Got", ptr, ptr2)
+	fmt.Println("Changes", c1, c2)
+
+	// Output:
+	// Got custom error custom error
+	// Got custom error gumi
+	// Changes <nil> {custom error gumi}
+}
+
+func ExampleDir_ensureCacheLeak() {
+	dir := fred.Dir{
+		"heya": fred.Error("custom error"),
+		"suya": fred.Error("suya is suya"),
+		"ptr":  fred.Ref("heya"),
+	}
+	s := fred.NewDirStream(dir, nil)
+	_, s1 := s.Eval(fred.Ref("ptr"))
+	s.Eval(fred.Ref("suya"))
+
+	s.Stream.Append(nil)
+	_, _ = s1.Next()
+	snext, _ := s.Next()
+
+	fmt.Println(s.Cache[fred.Ref("suya")], snext.Cache[fred.Ref("suya")])
+
+	// Output: suya is suya <nil>
+}

--- a/fred/func.go
+++ b/fred/func.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package fred
+
+import "github.com/dotchain/dot/changes"
+
+// Functor is the interface to be implemented by user defined functions
+type Functor interface {
+	// Eval should evaluate the function in the context of the dir.
+	//
+	// The objects provided are unevaluated -- it is up to the
+	// implementation to evaluate it if needed.
+	//
+	// The return value is likely to be cached
+	// automatically. dir.Cache can be used to cache interesting
+	// values but at this point there is no simple way to create
+	// an appropriate cache key.  At some point, a context can be
+	// provided to enable such caching
+	Eval(dir *DirStream, args []Object) Object
+
+	// Diff evaluates the chagne in value between old and new
+	Diff(old, next *DirStream, c changes.Change, args []Object) changes.Change
+}
+
+// Func is the placeholder for a function.  The actual implementation
+// of functions is in the Functor while this is just a wrapper to
+// marshal args values
+type Func struct {
+	Functor
+	Args interface{}
+}
+
+// Apply implements changes.Value
+func (f Func) Apply(ctx changes.Context, c changes.Change) changes.Value {
+	if c == nil {
+		return f
+	}
+	if replace, ok := c.(changes.Replace); ok {
+		return replace.After
+	}
+	return c.(changes.Custom).ApplyTo(ctx, f)
+}
+
+// Eval returns the calculated value
+func (f Func) Eval(dir *DirStream) Object {
+	if v, ok := dir.Cache[f]; ok {
+		return v
+	}
+	var result Object = f.Functor.Eval(dir, FromTuple(f.Args))
+	dir.Cache[f] = result
+	return result
+}
+
+// Diff returns the difference between old and new
+func (f Func) Diff(old, next *DirStream, c changes.Change) changes.Change {
+	if cx, ok := old.Changes[f]; ok {
+		return cx
+	}
+
+	cx := f.Functor.Diff(old, next, c, FromTuple(f.Args))
+	old.Changes[f] = cx
+	return cx
+}

--- a/fred/func_test.go
+++ b/fred/func_test.go
@@ -1,0 +1,77 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package fred_test
+
+import (
+	"testing"
+
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/fred"
+)
+
+type Func49 struct{}
+
+func (f Func49) Eval(dir *fred.DirStream, args []fred.Object) fred.Object {
+	if len(args) == 0 {
+		return fred.Error("No args")
+	}
+	return args[0].Eval(dir)
+}
+
+func (f Func49) Diff(old, next *fred.DirStream, c changes.Change, args []fred.Object) changes.Change {
+	if len(args) == 0 {
+		return nil
+	}
+	return args[0].Diff(old, next, c)
+}
+
+func TestFunc_noArgs(t *testing.T) {
+	dir := fred.Dir{
+		"heya":   fred.Error("custom error"),
+		"suya":   fred.Error("suya is suya"),
+		"foo":    fred.Func{Func49{}, nil},
+		"fooptr": fred.Ref("foo"),
+	}
+	s := fred.NewDirStream(dir, nil)
+	ptr, s1 := s.Eval(fred.Ref("fooptr"))
+	if ptr != fred.Error("No args") {
+		t.Error("Unexpected eval", ptr)
+	}
+	s.Stream.Append(nil)
+	if s1, c := s1.Next(); c != nil || s1 == nil || s1.Eval() != ptr {
+		t.Error("Unexpected", c, s1 == nil)
+	}
+
+}
+
+func TestFunc_refref(t *testing.T) {
+	dir := fred.Dir{
+		"heya": fred.Error("custom error"),
+		"suya": fred.Error("suya is suya"),
+		// the second ref is recursive and will crash the test if it is evaluated.
+		"foo": fred.Func{
+			Functor: Func49{},
+			Args:    fred.ToTuple([]fred.Object{fred.Ref("suya"), fred.Ref("foo")}),
+		},
+		"fooptr": fred.Ref("foo"),
+	}
+	s := fred.NewDirStream(dir, nil)
+	ptr, s1 := s.Eval(fred.Ref("fooptr"))
+	if ptr != dir["suya"] {
+		t.Error("Unexpected eval", ptr)
+	}
+	s.Stream.Append(changes.PathChange{
+		Path:   []interface{}{"suya"},
+		Change: changes.Replace{Before: dir["suya"], After: fred.Ref("heya")},
+	})
+
+	s1, c := s1.Next()
+	if s1.Eval() != dir["heya"] {
+		t.Error("unexpected val", s1.Eval())
+	}
+	if c != (changes.Replace{Before: ptr, After: dir["heya"]}) {
+		t.Error("unexpected change", c)
+	}
+}

--- a/fred/number.go
+++ b/fred/number.go
@@ -1,0 +1,31 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package fred
+
+import "github.com/dotchain/dot/changes"
+
+// Number uses a rational string format (i.e. p/q)
+type Number string
+
+// Apply implements changes.Value
+func (n Number) Apply(ctx changes.Context, c changes.Change) changes.Value {
+	if c == nil {
+		return n
+	}
+	if replace, ok := c.(changes.Replace); ok {
+		return replace.After
+	}
+	return c.(changes.Custom).ApplyTo(ctx, n)
+}
+
+// Eval evaluates to itself
+func (n Number) Eval(dir *DirStream) Object {
+	return n
+}
+
+// Diff returns the change from old to new
+func (n Number) Diff(old, next *DirStream, c changes.Change) changes.Change {
+	return nil
+}

--- a/fred/number_test.go
+++ b/fred/number_test.go
@@ -1,0 +1,66 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package fred_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/fred"
+)
+
+type NumSum struct{}
+
+func (f *NumSum) Eval(dir *fred.DirStream, args []fred.Object) fred.Object {
+	sum := big.NewRat(0, 1)
+	for _, arg := range args {
+		v := arg.Eval(dir)
+		n, ok := v.(fred.Number)
+		if !ok {
+			return fred.Error("non-numeric arg provided")
+		}
+		var r big.Rat
+		if err := r.UnmarshalText([]byte(string(n))); err != nil {
+			return fred.Error(err.Error())
+		}
+		sum.Add(sum, &r)
+	}
+	s, err := sum.MarshalText()
+	if err != nil {
+		return fred.Error(err.Error())
+	}
+	return fred.Number(string(s))
+}
+
+func (f *NumSum) Diff(old, next *fred.DirStream, c changes.Change, args []fred.Object) changes.Change {
+	before := f.Eval(old, args)
+	after := f.Eval(next, args)
+	if before == after {
+		return nil
+	}
+	return changes.Replace{Before: before, After: after}
+}
+
+func TestNum_sum(t *testing.T) {
+	dir := fred.Dir{
+		"one": fred.Number("1"),
+		"two": fred.Number("2"),
+		"three": fred.Func{
+			Functor: &NumSum{},
+			Args:    [2]fred.Object{fred.Ref("one"), fred.Ref("two")},
+		},
+		"six": fred.Func{
+			Functor: &NumSum{},
+			Args:    [2]fred.Object{fred.Ref("three"), fred.Ref("three")},
+		},
+		"sixptr": fred.Ref("six"),
+	}
+	s := fred.NewDirStream(dir, nil)
+	ptr, _ := s.Eval(fred.Ref("sixptr"))
+	if ptr != fred.Number("6") {
+		t.Error("Unexpected eval", ptr)
+	}
+}

--- a/fred/ref.go
+++ b/fred/ref.go
@@ -1,0 +1,56 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package fred
+
+import "github.com/dotchain/dot/changes"
+
+// NoRef is returned by Eval when a reference id does not exist
+var NoRef = Error("No value")
+
+// Ref refers to another object whose id is stored here
+type Ref string
+
+func (r Ref) Apply(ctx changes.Context, c changes.Change) changes.Value {
+	if c == nil {
+		return r
+	}
+	if replace, ok := c.(changes.Replace); ok {
+		return replace.After
+	}
+	return c.(changes.Custom).ApplyTo(ctx, r)
+}
+
+func (r Ref) Eval(dir *DirStream) Object {
+	if v, ok := dir.Cache[r]; ok {
+		return v
+	}
+	var result Object = NoRef
+	if v, ok := dir.Value[string(r)]; ok {
+		result = v.Eval(dir)
+	}
+	dir.Cache[r] = result
+	return result
+}
+
+func (r Ref) Next(old, next *DirStream, c changes.Change) (Object, changes.Change) {
+	cx, ok := old.Changes[r]
+
+	if !ok {
+		var v Object
+
+		after, ok := next.Value[string(r)]
+		if !ok {
+			after = NoRef
+		}
+		v, cx = after.Next(old, next, c)
+		next.Cache[r] = v.Eval(next)
+		if before, ok := old.Value[string(r)]; !ok || before != after {
+			cx = replace(r.Eval(old), next.Cache[r])
+		}
+		old.Changes[r] = cx
+	}
+
+	return r, cx
+}

--- a/fred/ref.go
+++ b/fred/ref.go
@@ -12,6 +12,7 @@ var NoRef = Error("No value")
 // Ref refers to another object whose id is stored here
 type Ref string
 
+// Apply implements changes.Value
 func (r Ref) Apply(ctx changes.Context, c changes.Change) changes.Value {
 	if c == nil {
 		return r
@@ -22,6 +23,7 @@ func (r Ref) Apply(ctx changes.Context, c changes.Change) changes.Value {
 	return c.(changes.Custom).ApplyTo(ctx, r)
 }
 
+// Eval returns the value pointed to by the Ref
 func (r Ref) Eval(dir *DirStream) Object {
 	if v, ok := dir.Cache[r]; ok {
 		return v
@@ -34,23 +36,23 @@ func (r Ref) Eval(dir *DirStream) Object {
 	return result
 }
 
-func (r Ref) Next(old, next *DirStream, c changes.Change) (Object, changes.Change) {
-	cx, ok := old.Changes[r]
-
-	if !ok {
-		var v Object
-
-		after, ok := next.Value[string(r)]
-		if !ok {
-			after = NoRef
-		}
-		v, cx = after.Next(old, next, c)
-		next.Cache[r] = v.Eval(next)
-		if before, ok := old.Value[string(r)]; !ok || before != after {
-			cx = replace(r.Eval(old), next.Cache[r])
-		}
-		old.Changes[r] = cx
+// Diff returns the difference between old and new
+func (r Ref) Diff(old, next *DirStream, c changes.Change) changes.Change {
+	if cx, ok := old.Changes[r]; ok {
+		return cx
 	}
 
-	return r, cx
+	after, ok := next.Value[string(r)]
+	if !ok {
+		after = NoRef
+	}
+
+	cx := after.Diff(old, next, c)
+	if before, ok := old.Value[string(r)]; !ok || before != after {
+		cx = replace(r.Eval(old), r.Eval(next))
+	}
+	// TODO: is this needed? it may make things a bit more efficient
+	// next.Cache[r] = r.Eval(old).Apply(nil, cx).(Object)
+	old.Changes[r] = cx
+	return cx
 }

--- a/fred/tuple.go
+++ b/fred/tuple.go
@@ -1,0 +1,38 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package fred
+
+import "reflect"
+
+// ToTuple converts a slice of objects into an array
+func ToTuple(objects []Object) interface{} {
+	if len(objects) == 0 {
+		return nil
+	}
+	t := reflect.ArrayOf(len(objects), reflect.TypeOf([]Object{}).Elem())
+	result := reflect.New(t).Elem()
+	for i, o := range objects {
+		if o != nil {
+			result.Index(i).Set(reflect.ValueOf(o))
+		}
+	}
+	//reflect.Copy(result.Slice(0, len(objects)), reflect.ValueOf(objects))
+	return result.Interface()
+}
+
+// FromTuple converts an array of objects into a slice
+func FromTuple(v interface{}) []Object {
+	if v == nil {
+		return nil
+	}
+	r := reflect.ValueOf(v)
+	result := make([]Object, r.Len())
+	for kk := 0; kk < r.Len(); kk++ {
+		if v := r.Index(kk).Interface(); v != nil {
+			result[kk] = v.(Object)
+		}
+	}
+	return result
+}

--- a/fred/tuple_test.go
+++ b/fred/tuple_test.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package fred_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/dotchain/dot/fred"
+)
+
+func TestTupleZeroElements(t *testing.T) {
+	if x := fred.ToTuple([]fred.Object{}); x != nil {
+		t.Error("Unexpected", x)
+	}
+	if x := fred.FromTuple(nil); len(x) != 0 {
+		t.Error("Unexpected", x)
+	}
+}
+
+func TestTupleTenElements(t *testing.T) {
+	array := [...]fred.Object{fred.Error("0"), nil, nil, fred.Error("1"), nil, nil, nil, nil, nil, nil}
+	slice := array[:]
+
+	if x := fred.ToTuple(slice); !reflect.DeepEqual(x, array) {
+		t.Error("Unexpected", x)
+	}
+	if x := fred.FromTuple(array); !reflect.DeepEqual(x, slice) {
+		t.Error("Unexpected", x)
+	}
+}


### PR DESCRIPTION
Fred is an experimental functional reactive engine on top of DOT.  Note that this is a "weakly typed" setup (where the dynamically created expressions are typeless and interpreted).  A strongly typed setup will very likely approach from the language side rather than ground up but this is easier and useful in its own right. The plan is to learn from this and then figure out how to properly divide boundaries and get type safety.

1. Dir holds directory of object defintions
2. Values can be evaluated.  All evaluations are *live* using a stream-like interface
3. Recalcuations are pull-based, so items not *pulled* will generally incur no cost
4. Cache of common values and expressions to avoid recomputation.

The directory only implements error values and references right now. Rich types are
not difficult but the motivation for this experiment is mostly to see how to sensibly
editing calculated values.  For instance, what does it mean to edit the value of a reference?

TODO

- [ ] Add ability to get provenance of some path in a value (i.e. where this comes from originally).  The provenance for data is like stack trace for code on steroids.
- [ ] Add ability to mutate computed values.  The implementation is similar to provenancee but likely not the same for computed values.
- [ ] Add simple types (number, sum). These will likely be needed for illustrating the interesting parts of the above.
- [ ] Add generic functions (worth converting sum to a generic function)
- [ ] Add container types
- [ ] Add type conversion heuristics