### PR TITLE
richtext: add data.Table

### DIFF
--- a/x/rich/data/cells.go
+++ b/x/rich/data/cells.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package data
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+	"github.com/dotchain/dot/x/rich"
+)
+
+// Cells represents a row of data.
+//
+// The key in the map is the column ID. If a column ID exists in the
+// map, the value cannot be nil.
+type Cells map[interface{}]*rich.Text
+
+// Apply implements changes.Value
+func (cells Cells) Apply(ctx changes.Context, c changes.Change) changes.Value {
+	return (types.Generic{Set: cells.set, Get: cells.get}).Apply(ctx, c, cells)
+}
+
+func (cells Cells) get(key interface{}) changes.Value {
+	if v, ok := cells[key]; ok {
+		return *v
+	}
+	return changes.Nil
+}
+
+func (cells Cells) set(key interface{}, v changes.Value) changes.Value {
+	clone := Cells{}
+	for k, val := range cells {
+		if k != key {
+			clone[k] = val
+		}
+	}
+	if v != changes.Nil {
+		x := v.(rich.Text)
+		clone[key] = &x
+	}
+	return clone
+}

--- a/x/rich/data/cells_test.go
+++ b/x/rich/data/cells_test.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package data_test
+
+import (
+	"testing"
+
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/x/rich"
+	"github.com/dotchain/dot/x/rich/data"
+)
+
+func TestCells(t *testing.T) {
+	cells := data.Cells{}
+	cells = cells.Apply(nil, changes.PathChange{
+		Path: []interface{}{"col1"},
+		Change: changes.Replace{
+			Before: changes.Nil,
+			After:  rich.NewText("cell1"),
+		},
+	}).(data.Cells)
+
+	if v, ok := cells["col1"]; !ok || v.PlainText() != "cell1" {
+		t.Error("Unexpected apply", v, ok)
+	}
+
+	cells = cells.Apply(nil, changes.PathChange{
+		Path: []interface{}{"col1"},
+		Change: changes.Replace{
+			Before: rich.NewText("cell1"),
+			After:  changes.Nil,
+		},
+	}).(data.Cells)
+
+	if v, ok := cells["col1"]; ok {
+		t.Error("Unexpected apply", v, ok)
+	}
+}

--- a/x/rich/data/col.go
+++ b/x/rich/data/col.go
@@ -1,0 +1,48 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package data
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+	"github.com/dotchain/dot/x/rich"
+)
+
+// Col represents the information about the column.
+//
+// The ID field is immutable.  The Ord field is meant to help sort the
+// columns and is not meant to be directly modified by the
+// application. Instead, Table methods can be used to effectively
+// manipulate these.
+//
+// The value field tracks the actual heading/name for the column and
+// should not be nil.
+type Col struct {
+	ID    interface{}
+	Ord   string
+	Value *rich.Text
+}
+
+// Apply implements changes.Value
+func (col Col) Apply(ctx changes.Context, c changes.Change) changes.Value {
+	return (types.Generic{Set: col.set, Get: col.get}).Apply(ctx, c, col)
+}
+
+func (col Col) get(key interface{}) changes.Value {
+	if key == "Ord" {
+		return types.S16(col.Ord)
+	}
+	return *col.Value
+}
+
+func (col Col) set(key interface{}, v changes.Value) changes.Value {
+	if key == "Ord" {
+		col.Ord = string(v.(types.S16))
+	} else {
+		x := v.(rich.Text)
+		col.Value = &x
+	}
+	return col
+}

--- a/x/rich/data/col_test.go
+++ b/x/rich/data/col_test.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package data_test
+
+import (
+	"testing"
+
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+	"github.com/dotchain/dot/x/rich"
+	"github.com/dotchain/dot/x/rich/data"
+)
+
+func TestCol(t *testing.T) {
+	v1, v2 := rich.NewText("value1"), rich.NewText("value2")
+	col := data.Col{ID: "col1", Value: &v1}
+	col = col.Apply(nil, changes.PathChange{
+		Path: []interface{}{"Ord"},
+		Change: changes.Replace{
+			Before: types.S16(""),
+			After:  types.S16("boo"),
+		},
+	}).(data.Col)
+
+	if col.Ord != "boo" {
+		t.Error("Unexpected ord change", col.Ord)
+	}
+
+	col = col.Apply(nil, changes.PathChange{
+		Path:   []interface{}{"Value"},
+		Change: changes.Replace{Before: v1, After: v2},
+	}).(data.Col)
+
+	if col.Value.PlainText() != v2.PlainText() {
+		t.Error("Unexpected value", col.Value.PlainText())
+	}
+}

--- a/x/rich/data/cols.go
+++ b/x/rich/data/cols.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package data
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+)
+
+// Cols represents all the columns in the table
+type Cols map[interface{}]*Col
+
+// Apply implements changes.Value
+func (cols Cols) Apply(ctx changes.Context, c changes.Change) changes.Value {
+	return (types.Generic{Set: cols.set, Get: cols.get}).Apply(ctx, c, cols)
+}
+
+func (cols Cols) get(key interface{}) changes.Value {
+	if v, ok := cols[key]; ok {
+		return *v
+	}
+	return changes.Nil
+}
+
+func (cols Cols) set(key interface{}, v changes.Value) changes.Value {
+	clone := Cols{}
+	for k, val := range cols {
+		if k != key {
+			clone[k] = val
+		}
+	}
+	if v != changes.Nil {
+		x := v.(Col)
+		clone[key] = &x
+	}
+	return clone
+}

--- a/x/rich/data/cols_test.go
+++ b/x/rich/data/cols_test.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package data_test
+
+import (
+	"testing"
+
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/x/rich"
+	"github.com/dotchain/dot/x/rich/data"
+)
+
+func TestCols(t *testing.T) {
+	col1, col2 := rich.NewText("col1"), rich.NewText("col2")
+	cols := data.Cols{}
+	cols = cols.Apply(nil, changes.PathChange{
+		Path: []interface{}{"col1"},
+		Change: changes.Replace{
+			Before: changes.Nil,
+			After:  data.Col{ID: "col1", Value: &col1},
+		},
+	}).(data.Cols)
+
+	cols = cols.Apply(nil, changes.PathChange{
+		Path: []interface{}{"col2"},
+		Change: changes.Replace{
+			Before: changes.Nil,
+			After:  data.Col{ID: "col2", Value: &col2},
+		},
+	}).(data.Cols)
+
+	if v, ok := cols["col1"]; !ok || v.ID != "col1" {
+		t.Error("Unexpected apply", v, ok)
+	}
+
+	if v, ok := cols["col2"]; !ok || v.ID != "col2" {
+		t.Error("Unexpected apply", v, ok)
+	}
+
+	cols = cols.Apply(nil, changes.PathChange{
+		Path: []interface{}{"col1"},
+		Change: changes.Replace{
+			Before: data.Col{ID: "col1", Value: &col1},
+			After:  data.Col{ID: "col1", Value: &col2},
+		},
+	}).(data.Cols)
+
+	if v, ok := cols["col1"]; v.Value.PlainText() != "col2" {
+		t.Error("Unexpected apply", v, ok)
+	}
+}

--- a/x/rich/data/row.go
+++ b/x/rich/data/row.go
@@ -1,0 +1,45 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package data
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+)
+
+// Row represents the information about a row
+//
+// The ID field is immutable.  The Ord field is meant to help sort the
+// rows and is not meant to be directly modified by the
+// application. Instead, Table methods can be used to effectively
+// manipulate these.
+//
+// The Cells field contains a map of Column.ID to actual cell value
+type Row struct {
+	ID  interface{}
+	Ord string
+	Cells
+}
+
+// Apply implements changes.Value
+func (r Row) Apply(ctx changes.Context, c changes.Change) changes.Value {
+	return (types.Generic{Set: r.set, Get: r.get}).Apply(ctx, c, r)
+}
+
+func (r Row) get(key interface{}) changes.Value {
+	if key == "Ord" {
+		return types.S16(r.Ord)
+	}
+	return r.Cells
+}
+
+func (r Row) set(key interface{}, v changes.Value) changes.Value {
+	if key == "Ord" {
+		r.Ord = string(v.(types.S16))
+	} else {
+		r.Cells = v.(Cells)
+	}
+	return r
+}

--- a/x/rich/data/row_test.go
+++ b/x/rich/data/row_test.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package data_test
+
+import (
+	"testing"
+
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+	"github.com/dotchain/dot/x/rich"
+	"github.com/dotchain/dot/x/rich/data"
+)
+
+func TestRow(t *testing.T) {
+	row := data.Row{ID: "row1"}
+	row = row.Apply(nil, changes.PathChange{
+		Path: []interface{}{"Ord"},
+		Change: changes.Replace{
+			Before: types.S16(""),
+			After:  types.S16("boo"),
+		},
+	}).(data.Row)
+
+	if row.Ord != "boo" {
+		t.Error("Unexpected ord change", row.Ord)
+	}
+
+	row = row.Apply(nil, changes.PathChange{
+		Path: []interface{}{"Cells", "col1"},
+		Change: changes.Replace{
+			Before: changes.Nil,
+			After:  rich.NewText("cell1"),
+		},
+	}).(data.Row)
+
+	if row.Cells["col1"].PlainText() != "cell1" {
+		t.Error("Unexpected value", row.Cells["col1"].PlainText())
+	}
+}

--- a/x/rich/data/rows.go
+++ b/x/rich/data/rows.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package data
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+)
+
+// Rows represents all the rows in the table
+type Rows map[interface{}]*Row
+
+// Apply implements changes.Value
+func (rows Rows) Apply(ctx changes.Context, c changes.Change) changes.Value {
+	return (types.Generic{Set: rows.set, Get: rows.get}).Apply(ctx, c, rows)
+}
+
+func (rows Rows) get(key interface{}) changes.Value {
+	if v, ok := rows[key]; ok {
+		return *v
+	}
+	return changes.Nil
+}
+
+func (rows Rows) set(key interface{}, v changes.Value) changes.Value {
+	clone := Rows{}
+	for k, val := range rows {
+		if k != key {
+			clone[k] = val
+		}
+	}
+	if v != changes.Nil {
+		x := v.(Row)
+		clone[key] = &x
+	}
+	return clone
+}

--- a/x/rich/data/rows_test.go
+++ b/x/rich/data/rows_test.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package data_test
+
+import (
+	"testing"
+
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/x/rich/data"
+)
+
+func TestRows(t *testing.T) {
+	rows := data.Rows{}
+	rows = rows.Apply(nil, changes.PathChange{
+		Path: []interface{}{"row1"},
+		Change: changes.Replace{
+			Before: changes.Nil,
+			After:  data.Row{ID: "row1"},
+		},
+	}).(data.Rows)
+
+	rows = rows.Apply(nil, changes.PathChange{
+		Path: []interface{}{"row2"},
+		Change: changes.Replace{
+			Before: changes.Nil,
+			After:  data.Row{ID: "row2"},
+		},
+	}).(data.Rows)
+
+	if v, ok := rows["row1"]; !ok || v.ID != "row1" {
+		t.Error("Unexpected apply", v, ok)
+	}
+
+	if v, ok := rows["row2"]; !ok || v.ID != "row2" {
+		t.Error("Unexpected apply", v, ok)
+	}
+
+	rows = rows.Apply(nil, changes.PathChange{
+		Path: []interface{}{"row1"},
+		Change: changes.Replace{
+			Before: data.Row{ID: "row1"},
+			After:  changes.Nil,
+		},
+	}).(data.Rows)
+
+	if v, ok := rows["row1"]; ok {
+		t.Error("Unexpected apply", v, ok)
+	}
+}

--- a/x/rich/data/table.go
+++ b/x/rich/data/table.go
@@ -1,0 +1,224 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+// Package data impleements data structures for use with rich text
+package data
+
+import (
+	"sort"
+
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+	"github.com/dotchain/dot/x/rich"
+
+	// crdt is only used for ord management
+	"github.com/dotchain/dot/changes/crdt"
+)
+
+// Table represents a table with named columns and rows
+//
+// This is an immutable type and all mutation methods (like AppendCol)
+// return changes.Change (which can be applied to get the new Table)
+//
+// The rows and columns are stored in a map structure but ordered IDs
+// can be obtained via RowIDs and ColIDs
+type Table struct {
+	Cols
+	Rows
+}
+
+// ColIDs returns all the column IDs sorted in order
+func (t Table) ColIDs() []interface{} {
+	ids := make([]interface{}, 0, len(t.Cols))
+	for id := range t.Cols {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		c1, c2 := *t.Cols[ids[i]], *t.Cols[ids[j]]
+		return crdt.LessOrd(c1.Ord, c2.Ord)
+	})
+	return ids
+}
+
+// RowIDs returns all the row IDs sorted in order
+func (t Table) RowIDs() []interface{} {
+	ids := make([]interface{}, 0, len(t.Rows))
+	for id := range t.Rows {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		r1, r2 := *t.Rows[ids[i]], *t.Rows[ids[j]]
+		return crdt.LessOrd(r1.Ord, r2.Ord)
+	})
+	return ids
+}
+
+// UpdateCol takes a change meant for a columm value and wraps it
+// with the path of the column -- the resulting change can be applied
+// directly on the table.
+func (t Table) UpdateCol(colID interface{}, c changes.Change) changes.Change {
+	path := []interface{}{"Cols", colID, "Value"}
+	return changes.PathChange{Path: path, Change: c}
+}
+
+// UpdateCellValue takes a change meant for a cell value and wraps it
+// with the path of the column -- the resulting change can be applied
+// directly on the table.
+//
+// Note that the cell must exist (i.e the row must have a entry for
+// the colID)
+func (t Table) UpdateCellValue(rowID, colID interface{}, c changes.Change) changes.Change {
+	path := []interface{}{"Rows", rowID, "Cells", colID}
+	return changes.PathChange{Path: path, Change: c}
+}
+
+// SetCellValue sets the rich text for a cell. It works for rows which
+// don't have values for specific columns as well as rows where the
+// columns have a value already.
+func (t Table) SetCellValue(rowID, colID interface{}, r rich.Text) changes.Change {
+	c := changes.Replace{Before: changes.Nil, After: r}
+	row := *t.Rows[rowID]
+	if v, ok := row.Cells[colID]; ok {
+		c.Before = *v
+	}
+	path := []interface{}{"Rows", rowID, "Cells", colID}
+	return changes.PathChange{Path: path, Change: c}
+}
+
+// AppendCol adds a new column to the end of the sorted list.
+//
+// The column can already exist in which case it is simply moved.
+func (t Table) AppendCol(col Col) changes.Change {
+	if len(t.Cols) == 0 {
+		col.Ord = ""
+	} else {
+		ids := t.ColIDs()
+		last := *t.Cols[ids[len(ids)-1]]
+		col.Ord = crdt.NextOrd(last.Ord)
+	}
+	return t.insertOrReorderCol(col)
+}
+
+// InsertColBefore inserts a new column before another
+//
+// The column may already exist in which case it is simply moved
+func (t Table) InsertColBefore(col Col, beforeCol Col) changes.Change {
+	ids := t.ColIDs()
+	for kk, id := range ids {
+		if id == beforeCol.ID {
+			if kk == 0 {
+				col.Ord = crdt.PrevOrd(t.Cols[ids[0]].Ord)
+			} else {
+				l := t.Cols[ids[kk-1]].Ord
+				r := t.Cols[ids[kk]].Ord
+				col.Ord = crdt.BetweenOrd(l, r, 1)[0]
+			}
+			return t.insertOrReorderCol(col)
+		}
+	}
+	return nil
+}
+
+func (t Table) insertOrReorderCol(col Col) changes.Change {
+	if before := t.Cols[col.ID]; before != nil {
+		b, a := types.S16(before.Ord), types.S16(col.Ord)
+		c := changes.Replace{Before: b, After: a}
+		path := []interface{}{"Cols", col.ID, "Ord"}
+		return changes.PathChange{Path: path, Change: c}
+	}
+
+	c := changes.Replace{Before: changes.Nil, After: col}
+	path := []interface{}{"Cols", col.ID}
+	return changes.PathChange{Path: path, Change: c}
+}
+
+// AppendRow adds a new row to the end of the sorted list.
+//
+// The row can already exist in which case it is simply moved.
+func (t Table) AppendRow(row Row) changes.Change {
+	if len(t.Rows) == 0 {
+		row.Ord = ""
+	} else {
+		ids := t.RowIDs()
+		last := *t.Rows[ids[len(ids)-1]]
+		row.Ord = crdt.NextOrd(last.Ord)
+	}
+	return t.insertOrReorderRow(row)
+}
+
+// InsertRowBefore inserts a new row before another
+//
+// The row may already exist in which case it is simply moved
+func (t Table) InsertRowBefore(row Row, beforeRow Row) changes.Change {
+	ids := t.RowIDs()
+	for kk, id := range ids {
+		if id == beforeRow.ID {
+			if kk == 0 {
+				row.Ord = crdt.PrevOrd(t.Rows[ids[0]].Ord)
+			} else {
+				l := t.Rows[ids[kk-1]].Ord
+				r := t.Rows[ids[kk]].Ord
+				row.Ord = crdt.BetweenOrd(l, r, 1)[0]
+			}
+			return t.insertOrReorderRow(row)
+		}
+	}
+	return nil
+}
+
+func (t Table) insertOrReorderRow(row Row) changes.Change {
+	if before := t.Rows[row.ID]; before != nil {
+		b, a := types.S16(before.Ord), types.S16(row.Ord)
+		c := changes.Replace{Before: b, After: a}
+		path := []interface{}{"Rows", row.ID, "Ord"}
+		return changes.PathChange{Path: path, Change: c}
+	}
+
+	c := changes.Replace{Before: changes.Nil, After: row}
+	path := []interface{}{"Rows", row.ID}
+	return changes.PathChange{Path: path, Change: c}
+}
+
+// DeleteCol deletes a column by ID
+func (t Table) DeleteCol(colID interface{}) changes.Change {
+	var result changes.Change
+	if col, ok := t.Cols[colID]; ok {
+		c := changes.Replace{Before: *col, After: changes.Nil}
+		path := []interface{}{"Cols", colID}
+		result = changes.PathChange{Path: path, Change: c}
+	}
+	return result
+}
+
+// DeleteRow deletes a row by ID
+func (t Table) DeleteRow(rowID interface{}) changes.Change {
+	var result changes.Change
+	if r, ok := t.Rows[rowID]; ok {
+		c := changes.Replace{Before: *r, After: changes.Nil}
+		path := []interface{}{"Rows", rowID}
+		result = changes.PathChange{Path: path, Change: c}
+	}
+	return result
+}
+
+// Apply implements changes.Value
+func (t Table) Apply(ctx changes.Context, c changes.Change) changes.Value {
+	return (types.Generic{Set: t.set, Get: t.get}).Apply(ctx, c, t)
+}
+
+func (t Table) get(key interface{}) changes.Value {
+	if key == "Cols" {
+		return t.Cols
+	}
+	return t.Rows
+}
+
+func (t Table) set(key interface{}, v changes.Value) changes.Value {
+	if key == "Cols" {
+		t.Cols = v.(Cols)
+	} else {
+		t.Rows = v.(Rows)
+	}
+	return t
+}

--- a/x/rich/data/table_test.go
+++ b/x/rich/data/table_test.go
@@ -1,0 +1,197 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package data_test
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/x/rich"
+	"github.com/dotchain/dot/x/rich/data"
+)
+
+func ExampleTable() {
+	t := data.Table{}
+	col1, col2 := rich.NewText("col1"), rich.NewText("col2")
+	t = t.Apply(nil, t.AppendCol(data.Col{ID: "col2", Value: &col2})).(data.Table)
+	t = t.Apply(nil, t.InsertColBefore(data.Col{ID: "col1", Value: &col1}, *t.Cols["col2"])).(data.Table)
+
+	t = t.Apply(nil, t.AppendRow(data.Row{ID: "row1"})).(data.Table)
+	t = t.Apply(nil, t.SetCellValue("row1", "col1", rich.NewText("1-1"))).(data.Table)
+	t = t.Apply(nil, t.SetCellValue("row1", "col2", rich.NewText("1-2"))).(data.Table)
+
+	fmt.Println(tableToText(t))
+
+	// Output: 1-1 1-2
+}
+
+func tableToText(t data.Table) string {
+	lines := []string{}
+	colIDs := t.ColIDs()
+	for _, rowID := range t.RowIDs() {
+		cells := []string{}
+		r := *t.Rows[rowID]
+		for _, colID := range colIDs {
+			cell := ""
+			if v, ok := r.Cells[colID]; ok {
+				cell = v.PlainText()
+			}
+			cells = append(cells, cell)
+		}
+		lines = append(lines, strings.Join(cells, " "))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func TestTableUpdateCol(t *testing.T) {
+	col1 := rich.NewText("col1")
+	tbl := data.Table{
+		Cols: data.Cols{
+			"col1": &data.Col{
+				ID:    "col1",
+				Value: &col1,
+			},
+		},
+	}
+
+	c := changes.Move{Offset: 3, Count: 1, Distance: -3}
+	tbl = tbl.Apply(nil, tbl.UpdateCol("col1", c)).(data.Table)
+
+	if x := tbl.Cols["col1"].Value.PlainText(); x != "1col" {
+		t.Error("Unexpected", x)
+	}
+}
+
+func TestTableDeleteCol(t *testing.T) {
+	col1 := rich.NewText("col1")
+	tbl := data.Table{
+		Cols: data.Cols{
+			"col1": &data.Col{
+				ID:    "col1",
+				Value: &col1,
+			},
+		},
+	}
+
+	tbl = tbl.Apply(nil, tbl.DeleteCol("col1")).(data.Table)
+
+	if x, ok := tbl.Cols["col1"]; ok {
+		t.Error("Unexpected", x)
+	}
+}
+
+func TestTableUpdateCellValue(t *testing.T) {
+	val := rich.NewText("val1")
+	tbl := data.Table{
+		Rows: data.Rows{
+			"row1": &data.Row{
+				ID:    "row1",
+				Cells: data.Cells{"col1": &val},
+			},
+		},
+	}
+
+	c := changes.Move{Offset: 3, Count: 1, Distance: -3}
+	tbl = tbl.Apply(nil, tbl.UpdateCellValue("row1", "col1", c)).(data.Table)
+
+	if x := tbl.Rows["row1"].Cells["col1"].PlainText(); x != "1val" {
+		t.Error("Unexpected", x)
+	}
+}
+
+func TestTableSetCellValue(t *testing.T) {
+	val := rich.NewText("val1")
+	tbl := data.Table{Rows: data.Rows{"row1": &data.Row{ID: "row1"}}}
+
+	tbl = tbl.Apply(nil, tbl.SetCellValue("row1", "col1", val)).(data.Table)
+
+	if x := tbl.Rows["row1"].Cells["col1"].PlainText(); x != "val1" {
+		t.Error("Unexpected", x)
+	}
+
+	val = rich.NewText("val2")
+
+	tbl = tbl.Apply(nil, tbl.SetCellValue("row1", "col1", val)).(data.Table)
+
+	if x := tbl.Rows["row1"].Cells["col1"].PlainText(); x != "val2" {
+		t.Error("Unexpected", x)
+	}
+}
+
+func TestTableDeleteRow(t *testing.T) {
+	tbl := data.Table{Rows: data.Rows{"row1": &data.Row{ID: "row1"}}}
+	tbl = tbl.Apply(nil, tbl.DeleteRow("row1")).(data.Table)
+
+	if x, ok := tbl.Rows["row1"]; ok {
+		t.Error("Unexpected", x)
+	}
+}
+
+func TestTableAppendCol(t *testing.T) {
+	tbl := data.Table{}
+	tbl = tbl.Apply(nil, tbl.AppendCol(data.Col{ID: "col1"})).(data.Table)
+	tbl = tbl.Apply(nil, tbl.AppendCol(data.Col{ID: "col2"})).(data.Table)
+	if x := tbl.ColIDs(); !reflect.DeepEqual(x, []interface{}{"col1", "col2"}) {
+		t.Error("Unexpected", x)
+	}
+
+	tbl = tbl.Apply(nil, tbl.AppendCol(*tbl.Cols["col1"])).(data.Table)
+	if x := tbl.ColIDs(); !reflect.DeepEqual(x, []interface{}{"col2", "col1"}) {
+		t.Error("Unexpected", x)
+	}
+}
+
+func TestTableInsertColBefore(t *testing.T) {
+	tbl := data.Table{Cols: data.Cols{"col3": &data.Col{ID: "col3"}}}
+
+	col3 := *tbl.Cols["col3"]
+	tbl = tbl.Apply(nil, tbl.InsertColBefore(data.Col{ID: "col1"}, col3)).(data.Table)
+	tbl = tbl.Apply(nil, tbl.InsertColBefore(data.Col{ID: "col2"}, col3)).(data.Table)
+
+	if x := tbl.ColIDs(); !reflect.DeepEqual(x, []interface{}{"col1", "col2", "col3"}) {
+		t.Error("Unexpected", x)
+	}
+
+	col1 := *tbl.Cols["col1"]
+	tbl = tbl.Apply(nil, tbl.InsertColBefore(col1, col3)).(data.Table)
+	if x := tbl.ColIDs(); !reflect.DeepEqual(x, []interface{}{"col2", "col1", "col3"}) {
+		t.Error("Unexpected", x)
+	}
+}
+
+func TestTableAppendRow(t *testing.T) {
+	tbl := data.Table{}
+	tbl = tbl.Apply(nil, tbl.AppendRow(data.Row{ID: "row1"})).(data.Table)
+	tbl = tbl.Apply(nil, tbl.AppendRow(data.Row{ID: "row2"})).(data.Table)
+	if x := tbl.RowIDs(); !reflect.DeepEqual(x, []interface{}{"row1", "row2"}) {
+		t.Error("Unexpected", x)
+	}
+
+	tbl = tbl.Apply(nil, tbl.AppendRow(*tbl.Rows["row1"])).(data.Table)
+	if x := tbl.RowIDs(); !reflect.DeepEqual(x, []interface{}{"row2", "row1"}) {
+		t.Error("Unexpected", x)
+	}
+}
+
+func TestTableInsertRowBefore(t *testing.T) {
+	tbl := data.Table{Rows: data.Rows{"row3": &data.Row{ID: "row3"}}}
+
+	row3 := *tbl.Rows["row3"]
+	tbl = tbl.Apply(nil, tbl.InsertRowBefore(data.Row{ID: "row1"}, row3)).(data.Table)
+	tbl = tbl.Apply(nil, tbl.InsertRowBefore(data.Row{ID: "row2"}, row3)).(data.Table)
+
+	if x := tbl.RowIDs(); !reflect.DeepEqual(x, []interface{}{"row1", "row2", "row3"}) {
+		t.Error("Unexpected", x)
+	}
+
+	row1 := *tbl.Rows["row1"]
+	tbl = tbl.Apply(nil, tbl.InsertRowBefore(row1, row3)).(data.Table)
+	if x := tbl.RowIDs(); !reflect.DeepEqual(x, []interface{}{"row2", "row1", "row3"}) {
+		t.Error("Unexpected", x)
+	}
+}


### PR DESCRIPTION
This change only adds the table datastructure (based only on maps). It does not support making this an embed in rich.Text, that part will be a separate CL.