### PR TITLE
rich/eval: derived values with declarative derivation

### DIFF
--- a/x/rich/eval/array.go
+++ b/x/rich/eval/array.go
@@ -6,14 +6,10 @@
 package eval
 
 import (
-	"errors"
-
 	"github.com/dotchain/dot/changes"
 	"github.com/dotchain/dot/changes/types"
 	"github.com/dotchain/dot/x/rich/data"
 )
-
-var errInvalidArgs = errors.New("invalid arguments")
 
 type array types.A
 

--- a/x/rich/eval/array.go
+++ b/x/rich/eval/array.go
@@ -1,0 +1,55 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+// Package eval implements evaluated objects
+package eval
+
+import (
+	"errors"
+
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+	"github.com/dotchain/dot/x/rich/data"
+)
+
+var errInvalidArgs = errors.New("invalid arguments")
+
+type array types.A
+
+func (a array) forEach(s Scope, args []changes.Value) changes.Value {
+	if len(args) != 1 {
+		return changes.Atomic{Value: errInvalidArgs}
+	}
+
+	result := make(types.A, len(a))
+	for kk, elt := range a {
+		result[kk] = Eval(s, &data.Dir{
+			Root: args[0],
+			Objects: types.M{
+				types.S16("index"): changes.Atomic{Value: kk},
+				types.S16("value"): elt,
+			},
+		})
+	}
+	return result
+}
+
+func (a array) reduce(s Scope, args []changes.Value) changes.Value {
+	if len(args) != 2 {
+		return changes.Atomic{Value: errInvalidArgs}
+	}
+
+	var result = Eval(s, args[0])
+	for kk, elt := range a {
+		result = Eval(s, &data.Dir{
+			Root: args[1],
+			Objects: types.M{
+				types.S16("index"): changes.Atomic{Value: kk},
+				types.S16("value"): elt,
+				types.S16("last"):  result,
+			},
+		})
+	}
+	return result
+}

--- a/x/rich/eval/call.go
+++ b/x/rich/eval/call.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package eval
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+)
+
+// Call represents a "call" expression. The first element of the array
+// is expected to be "Callable" which can be called with the rest as
+// args.
+//
+// All errors result in a nil result.
+type Call struct {
+	types.A
+}
+
+// Eval evaluates a call expression in the provided scope
+func (cx *Call) Eval(s Scope) changes.Value {
+	if len(cx.A) == 0 {
+		return changes.Nil
+	}
+
+	v := Eval(s, cx.A[0])
+	if fn, ok := v.(Callable); ok {
+		return fn(s, cx.A[1:])
+	}
+
+	return changes.Nil
+}
+
+// Apply implements changes.Value.
+func (cx *Call) Apply(ctx changes.Context, c changes.Change) changes.Value {
+	return (types.Generic{Set: cx.set, Get: cx.get}).Apply(ctx, c, cx)
+}
+
+func (cx *Call) get(key interface{}) changes.Value {
+	return cx.A
+}
+
+func (cx *Call) set(key interface{}, v changes.Value) changes.Value {
+	return &Call{v.(types.A)}
+}

--- a/x/rich/eval/call.go
+++ b/x/rich/eval/call.go
@@ -20,16 +20,12 @@ type Call struct {
 
 // Eval evaluates a call expression in the provided scope
 func (cx *Call) Eval(s Scope) changes.Value {
-	if len(cx.A) == 0 {
-		return changes.Nil
-	}
-
 	v := Eval(s, cx.A[0])
 	if fn, ok := v.(Callable); ok {
 		return fn(s, cx.A[1:])
 	}
 
-	return changes.Nil
+	return changes.Atomic{Value: errNotCallable}
 }
 
 // Apply implements changes.Value.

--- a/x/rich/eval/call_test.go
+++ b/x/rich/eval/call_test.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package eval_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+	"github.com/dotchain/dot/x/rich/eval"
+)
+
+func TestCall(t *testing.T) {
+	cx := &eval.Call{types.A{types.S16("boo")}}
+	if x := cx.Apply(nil, nil); !reflect.DeepEqual(cx, x) {
+		t.Error("Unexpected nil apply", x)
+	}
+
+	c := changes.PathChange{
+		Path:   []interface{}{"A"},
+		Change: changes.Replace{Before: cx.A, After: types.A{types.S16("hoo")}},
+	}
+	expected := &eval.Call{types.A{types.S16("hoo")}}
+	if x := cx.Apply(nil, c); !reflect.DeepEqual(x, expected) {
+		t.Error("Unexpected apply", x)
+	}
+}

--- a/x/rich/eval/callable.go
+++ b/x/rich/eval/callable.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package eval
+
+import (
+	"errors"
+
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+)
+
+// Callable wraps a function into a value type that can be called
+type Callable func(s Scope, args []changes.Value) changes.Value
+
+// Apply implements changes.Value
+func (cx Callable) Apply(ctx changes.Context, c changes.Change) changes.Value {
+	switch c := c.(type) {
+	case nil:
+		return cx
+	case changes.Replace:
+		return c.After
+	}
+	return c.(changes.Custom).ApplyTo(ctx, cx)
+}
+
+// Sum is the "callable" which evaluates the sum of all args
+//
+// Non-numeric values are treated as zeros
+var Sum Callable = func(s Scope, args []changes.Value) changes.Value {
+	var sum int
+	for _, arg := range args {
+		atomic, _ := Eval(s, arg).(changes.Atomic)
+		val, _ := atomic.Value.(int)
+		sum += val
+	}
+	return changes.Atomic{Value: sum}
+}
+
+// Dot is the "callable" which evaluates args[0].args[1].args[2]...
+var Dot Callable = func(s Scope, args []changes.Value) changes.Value {
+	var receiver changes.Value = changes.Nil
+	if len(args) > 0 {
+		receiver = args[0]
+		for _, arg := range args[1:] {
+			receiver = dot(s, receiver, arg)
+		}
+	}
+	return receiver
+}
+
+func dot(s Scope, receiver, field changes.Value) changes.Value {
+	receiver = Eval(s, receiver)
+	field = Eval(s, field)
+	if r, ok := receiver.(types.A); ok {
+		switch field {
+		case types.S16("count"):
+			return changes.Atomic{Value: r.Count()}
+		case types.S16("map"):
+			return Callable(array(r).forEach)
+		case types.S16("reduce"):
+			return Callable(array(r).reduce)
+		default:
+			return changes.Atomic{Value: errors.New("unknown field")}
+		}
+	}
+	return changes.Atomic{Value: errors.New("unknown receiver")}
+}

--- a/x/rich/eval/callable.go
+++ b/x/rich/eval/callable.go
@@ -5,8 +5,6 @@
 package eval
 
 import (
-	"errors"
-
 	"github.com/dotchain/dot/changes"
 	"github.com/dotchain/dot/changes/types"
 )
@@ -110,11 +108,10 @@ func equality(fn func(x, y changes.Value) bool) func(s Scope, args []changes.Val
 	}
 }
 
-var errUnknownField = errors.New("unknown field")
-
 func dot(s Scope, receiver, field changes.Value) changes.Value {
 	receiver = Eval(s, receiver)
 	field = Eval(s, field)
+
 	if r, ok := receiver.(types.A); ok {
 		return array(r).getField(field)
 	}
@@ -123,5 +120,9 @@ func dot(s Scope, receiver, field changes.Value) changes.Value {
 		return dict(d).getField(field)
 	}
 
-	return changes.Atomic{Value: errors.New("unknown receiver")}
+	if s, ok := receiver.(types.S16); ok {
+		return str(s).getField(field)
+	}
+
+	return changes.Atomic{Value: errUnknownReceiver}
 }

--- a/x/rich/eval/callable_test.go
+++ b/x/rich/eval/callable_test.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package eval_test
+
+import (
+	"testing"
+
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+	"github.com/dotchain/dot/x/rich/eval"
+)
+
+func TestCallable(t *testing.T) {
+	before := eval.Callable(func(s eval.Scope, args []changes.Value) changes.Value {
+		return types.S16("before")
+	})
+	after := eval.Callable(func(s eval.Scope, args []changes.Value) changes.Value {
+		return types.S16("after")
+	})
+
+	c := changes.ChangeSet{
+		changes.Replace{Before: before, After: after},
+		nil,
+	}
+
+	x := before.Apply(nil, c)
+	if fn, ok := x.(eval.Callable); !ok || fn(nil, nil) != types.S16("after") {
+		t.Error("Unexpected apply result", x)
+	}
+}

--- a/x/rich/eval/dict.go
+++ b/x/rich/eval/dict.go
@@ -20,14 +20,10 @@ func (d dict) forEach(s Scope, args []changes.Value) changes.Value {
 
 	result := types.M{}
 	for key, elt := range d {
-		k, ok := key.(changes.Value)
-		if !ok {
-			k = changes.Atomic{Value: key}
-		}
 		result[key] = Eval(s, &data.Dir{
 			Root: args[0],
 			Objects: types.M{
-				types.S16("key"):   k,
+				types.S16("key"):   d.valueOf(key),
 				types.S16("value"): elt,
 			},
 		})
@@ -44,14 +40,10 @@ func (d dict) filter(s Scope, args []changes.Value) changes.Value {
 	for key, elt := range d {
 		// TODO: elt eval should be lazy?
 		elt = Eval(s, elt)
-		k, ok := key.(changes.Value)
-		if !ok {
-			k = changes.Atomic{Value: key}
-		}
 		v := Eval(s, &data.Dir{
 			Root: args[0],
 			Objects: types.M{
-				types.S16("key"):   k,
+				types.S16("key"):   d.valueOf(key),
 				types.S16("value"): elt,
 			},
 		})
@@ -71,14 +63,10 @@ func (d dict) reduce(s Scope, args []changes.Value) changes.Value {
 
 	result := Eval(s, args[0])
 	for key, elt := range d {
-		k, ok := key.(changes.Value)
-		if !ok {
-			k = changes.Atomic{Value: key}
-		}
 		result = Eval(s, &data.Dir{
 			Root: args[1],
 			Objects: types.M{
-				types.S16("key"):   k,
+				types.S16("key"):   d.valueOf(key),
 				types.S16("value"): elt,
 				types.S16("last"):  result,
 			},
@@ -104,4 +92,11 @@ func (d dict) getField(field changes.Value) changes.Value {
 	}
 
 	return changes.Atomic{Value: errUnknownField}
+}
+
+func (d dict) valueOf(v interface{}) changes.Value {
+	if key, ok := v.(changes.Value); ok {
+		return key
+	}
+	return changes.Atomic{Value: v}
 }

--- a/x/rich/eval/errors.go
+++ b/x/rich/eval/errors.go
@@ -1,0 +1,12 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package eval
+
+import "errors"
+
+var errUnknownField = errors.New("unknown field")
+var errUnknownReceiver = errors.New("unknown receiver")
+var errNotCallable = errors.New("not a function")
+var errInvalidArgs = errors.New("invalid arguments")

--- a/x/rich/eval/eval.go
+++ b/x/rich/eval/eval.go
@@ -1,0 +1,103 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+// Package eval implements expression values.
+//
+// An expression value can be produced by use of Parse:
+//
+//   eval.Parse(scope, "list.map(value + 2)")
+//   => equivalent to the following:
+//
+//   // first define all the tokens
+//   dot := &data.Ref{ID: types.S16(".")}
+//   plus := &data.Ref{ID: types.S16("+")}
+//   list := &data.Ref{ID: types.S16("list")}
+//   doMap := &data.Ref{ID: types.S16("map")}
+//   value := &data.Ref{ID: types.S16("value")}
+//   two := changes.Atomic{Value: 2}
+//
+//   now create a call expression for the above
+//   expr := &data.Call{A: types.A{
+//       // first element evaluates to list.map
+//       &data.Call{A: types.A{dot, list, doMap}},
+//       // second element represents value+2
+//       &data.Call{A: types.A{plus, value, two}},
+//   }}
+//
+// The scope contains the "globals" for evaluation, including all the
+// operators. But methods on objects (such as "map" on arrays) are not
+// part of the globals.
+//
+// An expression can be evaluated with Eval(). Eval converts call
+// expression to the actual evaluated values using the provided
+// scope.  Eval also walks the contents of any containers, replacing
+// any expressions with their evaluated values.  Eval also honors
+// references via Dir (so this is an easy way to create scopes).
+package eval
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+	"github.com/dotchain/dot/x/rich/data"
+)
+
+// Scope is any scope lookup function. Scope lookups are expected to
+// return evaluated values but nested fields may contain unevaluated
+// values.
+type Scope func(v interface{}) changes.Value
+
+// Eval evaluates a value within a particular scope
+//
+// Values of type CallExpr evaluate to the corresponding call.  All
+// other values are simply the same values but with any nested call
+// expressions evaluated.
+//
+// The provided scope is used to lookup IDs with Ref{} values. Any Dir
+// values automatically contribute by creating a new scope
+func Eval(s Scope, v changes.Value) changes.Value {
+	switch v := v.(type) {
+	case *Call:
+		return v.Eval(s)
+	case *data.Ref:
+		return s(v.ID)
+	case types.A:
+		return evalArray(s, v)
+	case *data.Dir:
+		return Eval((&dirScope{s, v.Objects, nil}).lookup, v.Root)
+	}
+	return v
+}
+
+func evalArray(s Scope, v types.A) changes.Value {
+	result := make(types.A, len(v))
+	for kk, elt := range v {
+		result[kk] = Eval(s, elt)
+	}
+	return result
+}
+
+type dirScope struct {
+	base       Scope
+	objects    types.M
+	inProgress map[interface{}]bool
+}
+
+func (s *dirScope) lookup(id interface{}) changes.Value {
+	val, ok := s.objects[id]
+	if !ok {
+		return s.base(id)
+	}
+
+	if s.inProgress[id] {
+		panic("recursion detected")
+	}
+	if s.inProgress == nil {
+		s.inProgress = map[interface{}]bool{}
+	}
+	s.inProgress[id] = true
+	defer func() {
+		s.inProgress[id] = false
+	}()
+	return Eval(s.lookup, val)
+}

--- a/x/rich/eval/eval_test.go
+++ b/x/rich/eval/eval_test.go
@@ -1,0 +1,56 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package eval_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+	"github.com/dotchain/dot/x/rich/eval"
+)
+
+func TestArrayMap(t *testing.T) {
+	var globals types.M
+	var scope eval.Scope
+
+	scope = eval.Scope(func(v interface{}) changes.Value {
+		return eval.Eval(scope, globals[v])
+	})
+	globals = types.M{
+		types.S16("+"):    eval.Sum,
+		types.S16("."):    eval.Dot,
+		types.S16("list"): eval.Parse(scope, "(1, 2, 3)"),
+	}
+
+	tests := map[string]string{
+		"list.map(value+10)":           "(11, 12, 13)",
+		"list.reduce(100, value+last)": "106",
+	}
+
+	t.Run("basic", func(t *testing.T) {
+		got := eval.Eval(scope, eval.Parse(scope, "list"))
+		expected := changes.Value(types.A{
+			changes.Atomic{Value: 1},
+			changes.Atomic{Value: 2},
+			changes.Atomic{Value: 3},
+		})
+
+		if !reflect.DeepEqual(got, expected) {
+			t.Errorf("Got %#v\n", got)
+		}
+	})
+
+	for code, result := range tests {
+		t.Run(code, func(t *testing.T) {
+			got := eval.Eval(scope, eval.Parse(scope, code))
+			expected := eval.Eval(scope, eval.Parse(scope, result))
+			if !reflect.DeepEqual(got, expected) {
+				t.Errorf("got %#v", got)
+			}
+		})
+	}
+}

--- a/x/rich/eval/eval_test.go
+++ b/x/rich/eval/eval_test.go
@@ -21,18 +21,19 @@ func TestEval(t *testing.T) {
 		return eval.Eval(scope, globals[v])
 	})
 	globals = types.M{
-		types.S16("+"):     eval.Sum,
-		types.S16("."):     eval.Dot,
-		types.S16("<"):     eval.NumLess,
-		types.S16("<="):    eval.NumLessThanEqual,
-		types.S16("=="):    eval.Equal,
-		types.S16(">"):     eval.NumMore,
-		types.S16(">="):    eval.NumMoreThanEqual,
-		types.S16("!="):    eval.NotEqual,
-		types.S16("true"):  changes.Atomic{Value: true},
-		types.S16("false"): changes.Atomic{Value: false},
-		types.S16("list"):  eval.Parse(scope, "(1, 2, 3)"),
-		types.S16("dict"):  eval.Parse(scope, "obj(x = 1, y = 5)"),
+		types.S16("+"):      eval.Sum,
+		types.S16("."):      eval.Dot,
+		types.S16("<"):      eval.NumLess,
+		types.S16("<="):     eval.NumLessThanEqual,
+		types.S16("=="):     eval.Equal,
+		types.S16(">"):      eval.NumMore,
+		types.S16(">="):     eval.NumMoreThanEqual,
+		types.S16("!="):     eval.NotEqual,
+		types.S16("true"):   changes.Atomic{Value: true},
+		types.S16("false"):  changes.Atomic{Value: false},
+		types.S16("list"):   eval.Parse(scope, "(1, 2, 3)"),
+		types.S16("dict"):   eval.Parse(scope, "obj(x = 1, y = 5)"),
+		types.S16("intmap"): types.M{5: types.S16("five")},
 	}
 
 	// map of code => expected result
@@ -57,6 +58,11 @@ func TestEval(t *testing.T) {
 		"0 > 1":                        "false",
 		"0 >= 1":                       "false",
 		"do(z + 2, z = list.count)":    "5",
+
+		"'hello'.count":            "5",
+		"'hello'.concat(' world')": "'hello world'",
+
+		"intmap.filter(key != 5)": "obj()",
 	}
 
 	for code, result := range tests {
@@ -67,5 +73,70 @@ func TestEval(t *testing.T) {
 				t.Errorf("got %#v", got)
 			}
 		})
+	}
+}
+
+func TestEvalErrors(t *testing.T) {
+	s := eval.Scope(func(v interface{}) changes.Value {
+		if v == types.S16(".") {
+			return eval.Dot
+		}
+		panic(string(v.(types.S16)))
+	})
+	fails := []string{
+		"(1, 2, 3).map()",
+		"(1, 2, 3).filter()",
+		"(1, 2, 3).reduce(100)",
+		"(1, 2, 3).boo",
+		"(1, 2, 3)()",
+		"(1, 2, 3).count.boo",
+		"obj(x = 5).map()",
+		"obj(x = 5).filter()",
+		"obj(x = 5).reduce(100)",
+		"obj(x = 5).boo",
+		"'boo'.boo",
+	}
+
+	for _, fail := range fails {
+		t.Run(fail, func(t *testing.T) {
+			got := eval.Eval(s, eval.Parse(nil, fail))
+			atomic, _ := got.(changes.Atomic)
+			err, _ := atomic.Value.(error)
+			if err == nil {
+				t.Errorf("Got unexpected non-error %#v", got)
+			}
+		})
+	}
+}
+
+func TestEvalPanics(t *testing.T) {
+	catch := func(fn func()) (v interface{}) {
+		defer func() {
+			v = recover()
+		}()
+		fn()
+		return nil
+	}
+
+	s := eval.Scope(func(v interface{}) changes.Value {
+		if v == types.S16(".") {
+			return eval.Dot
+		}
+		panic(string(v.(types.S16)))
+	})
+
+	v := catch(func() {
+		eval.Eval(s, eval.Parse(nil, "do(x, x = y, y = x)"))
+	})
+	if v != "recursion detected" {
+		t.Error("Unexpected recursion fail", v)
+	}
+
+	v = catch(func() {
+		eval.Eval(s, eval.Parse(nil, "obj(x = y, y = x).x"))
+	})
+
+	if v != "recursion detected" {
+		t.Error("Unexpected recursion fail", v)
 	}
 }

--- a/x/rich/eval/parse.go
+++ b/x/rich/eval/parse.go
@@ -1,0 +1,284 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package eval
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+	"github.com/dotchain/dot/x/rich/data"
+)
+
+// Parse converts an expression into the corresponding AST
+//
+// The result is not yet evaluated, and needs a call to Eval to work.
+func Parse(s Scope, code string) changes.Value {
+	var err error
+	p := parser{
+		Operators: map[string]*opInfo{
+			",": {Priority: 2, New: combineArgs},
+			"+": {Priority: 11, Prefix: 0, New: simpleCall("+")},
+
+			"(": {Priority: 20, BeginGroup: true},
+			")": {
+				Priority: 20,
+				EndGroup: func(b *opInfo, term changes.Value, start, end int) changes.Value {
+					// FIX: a.(x) will now incorrectly
+					// get evaluated to a.x.
+					// Fix is a bit intricate
+					// without extra unnecessary nodes
+					return term
+				},
+			},
+			".": {
+				Priority: 100,
+				New: func(l, r changes.Value) changes.Value {
+					if ref, ok := r.(*data.Ref); ok {
+						r = ref.ID.(changes.Value)
+					}
+					return simpleCall(".")(l, r)
+				},
+			},
+		},
+		Error: func(offset int, message string) {
+			err = fmt.Errorf("error at %d: %s", offset, message)
+		},
+		StringTerm: func(s string, first rune) changes.Value {
+			return types.S16(s)
+		},
+		NumericTerm: func(s string) changes.Value {
+			n, _ := strconv.Atoi(s)
+			return changes.Atomic{Value: n}
+		},
+		NameTerm: func(s string) changes.Value {
+			return &data.Ref{ID: types.S16(s)}
+		},
+		CallTerm: func(fn, args changes.Value) changes.Value {
+			a, ok := args.(types.A)
+			if !ok {
+				a = types.A{args}
+			}
+			return &Call{A: append(types.A{fn}, a...)}
+		},
+	}
+
+	v, rest := p.parse(code, 0)
+	if rest != "" {
+		err = fmt.Errorf("error at %d: unexpected charater", len(code)-len(rest))
+	}
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func simpleCall(op string) func(l, r changes.Value) changes.Value {
+	fn := &data.Ref{ID: types.S16(op)}
+	return func(l, r changes.Value) changes.Value {
+		return &Call{A: append(types.A{fn}, combineArgs(l, r).(types.A)...)}
+	}
+}
+
+func combineArgs(l, r changes.Value) changes.Value {
+	if x, ok := l.(types.A); ok {
+		return append(x, r)
+	}
+	return types.A{l, r}
+}
+
+type opInfo struct {
+	New      func(d1, d2 changes.Value) changes.Value
+	Priority int
+
+	Prefix interface{}
+
+	BeginGroup bool
+	EndGroup   func(beginGroup *opInfo, d changes.Value, beginOffset, endOffset int) changes.Value
+}
+
+type parser struct {
+	Operators map[string]*opInfo
+	Error     func(offset int, message string)
+
+	StringTerm  func(s string, first rune) changes.Value
+	NumericTerm func(s string) changes.Value
+	NameTerm    func(s string) changes.Value
+	CallTerm    func(fn, args changes.Value) changes.Value
+}
+
+func (p *parser) parse(input string, offset int) (changes.Value, string) {
+	lastWasTerm := false
+	ops := []*opInfo{}
+	terms := []changes.Value{}
+	prefixes := 0
+
+main:
+	for input != "" {
+		op, term, nextOffset, rest := p.scan(input, &offset)
+		switch {
+		case op != nil && op.EndGroup != nil:
+			break main
+		case op != nil && op.BeginGroup:
+			term, nextOffset, rest = p.parseGroup(op, rest, nextOffset)
+			if lastWasTerm {
+				ops, terms = p.merge(ops, terms, op.Priority)
+				terms[len(terms)-1] = p.CallTerm(terms[len(terms)-1], term)
+				break
+			}
+			fallthrough
+		case term != nil:
+			p.failIf(lastWasTerm, offset, "unexpected term")
+			for l := len(ops); prefixes > 0; prefixes, l = prefixes-1, l-1 {
+				prefix := changes.Atomic{Value: ops[l-1].Prefix}
+				term = ops[l-1].New(prefix, term)
+				ops = ops[:l-1]
+			}
+			terms = append(terms, term)
+			lastWasTerm = true
+		case op != nil:
+			if !lastWasTerm {
+				p.failIf(op.Prefix == nil, offset, "unexpected op")
+				prefixes++
+			} else {
+				ops, terms = p.merge(ops, terms, op.Priority)
+				lastWasTerm = false
+			}
+			ops = append(ops, op)
+		default:
+			input = rest
+			break main
+		}
+		offset, input = nextOffset, rest
+	}
+
+	if len(terms) == 0 && len(ops) == 0 {
+		return nil, input
+	}
+
+	p.failIf(!lastWasTerm || prefixes > 0, offset, "incomplete")
+
+	_, terms = p.merge(ops, terms, -1)
+	return terms[0], input
+}
+
+func (p *parser) parseGroup(begin *opInfo, input string, offset int) (changes.Value, int, string) {
+	group, rest := p.parse(input, offset)
+	offset += len(input) - len(rest)
+	op, _, nextOffset, rest := p.scan(rest, &offset)
+
+	p.failIf(op == nil || op.EndGroup == nil, nextOffset, "unexpected char")
+
+	return op.EndGroup(begin, group, offset, nextOffset), nextOffset, rest
+}
+
+func (p *parser) merge(ops []*opInfo, terms []changes.Value, pri int) ([]*opInfo, []changes.Value) {
+	for t, l := len(terms), len(ops); l > 0 && ops[l-1].Priority >= pri; t, l = t-1, l-1 {
+		terms[t-2] = ops[l-1].New(terms[t-2], terms[t-1])
+		ops, terms = ops[:l-1], terms[:t-1]
+	}
+	return ops, terms
+}
+
+func (p *parser) scan(s string, offset *int) (*opInfo, changes.Value, int, string) {
+	rest := strings.TrimLeftFunc(s, unicode.IsSpace)
+	*offset += len(s) - len(rest)
+	var op *opInfo
+	var match string
+
+	if rest == "" {
+		return nil, nil, *offset, rest
+	}
+
+	for pattern, opx := range p.Operators {
+		if len(pattern) <= len(match) || !strings.HasPrefix(rest, pattern) {
+			continue
+		}
+		op, match = opx, pattern
+	}
+
+	if op != nil {
+		return op, nil, *offset + len(match), rest[len(match):]
+	}
+
+	term, restx := p.scanTerm(rest, *offset)
+	return nil, term, *offset + len(rest) - len(restx), restx
+}
+
+func (p *parser) scanTerm(s string, offset int) (changes.Value, string) {
+	first, _ := utf8.DecodeRune([]byte(s))
+	if first == '"' || first == '\'' {
+		q, restx := p.scanQuote(s, offset)
+		return p.StringTerm(q, first), restx
+	}
+
+	if unicode.IsDigit(first) {
+		q, restx := p.scanNumeric(s)
+		return p.NumericTerm(q), restx
+	}
+
+	if q, restx := p.scanID(s); q != "" {
+		return p.NameTerm(q), restx
+	}
+
+	return nil, s
+}
+
+func (p *parser) scanQuote(s string, offset int) (quoted, rest string) {
+	var first rune
+	skip := false
+	result := []rune{}
+	for idx, r := range s {
+		switch {
+		case idx == 0:
+			first = r
+		case !skip && r == '\\':
+			skip = true
+		case !skip && r == first:
+			return string(result), s[idx+utf8.RuneLen(r):]
+		default:
+			result = append(result, r)
+			skip = false
+		}
+	}
+	p.fail(offset, "incomplete quote")
+	return "", ""
+}
+
+func (p *parser) scanNumeric(s string) (num, rest string) {
+	var f float64
+	_, err := fmt.Sscanf(s, "%f%s", &f, &rest)
+	if err != io.EOF {
+		idx := strings.Index(s, rest)
+		return s[:idx], s[idx:]
+	}
+	return s, ""
+}
+
+func (p *parser) scanID(s string) (id, rest string) {
+	for idx, r := range s {
+		if !unicode.IsLetter(r) && (idx == 0 || !unicode.IsDigit(r)) {
+			return s[:idx], s[idx:]
+		}
+	}
+	return s, ""
+}
+
+func (p *parser) fail(offset int, message string) {
+	p.Error(offset, message)
+	panic(message)
+}
+
+func (p *parser) failIf(cond bool, offset int, message string) {
+	if cond {
+		p.Error(offset, message)
+		panic(message)
+	}
+}

--- a/x/rich/eval/string.go
+++ b/x/rich/eval/string.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+// Package eval implements evaluated objects
+package eval
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/changes/types"
+)
+
+type str types.S16
+
+func (s str) concat(scope Scope, args []changes.Value) changes.Value {
+	return types.S16(string(s) + string(args[0].(types.S16)))
+}
+
+func (s str) getField(field changes.Value) changes.Value {
+	switch field {
+	case types.S16("count"):
+		return changes.Atomic{Value: types.S16(s).Count()}
+	case types.S16("concat"):
+		return Callable(s.concat)
+	}
+
+	return changes.Atomic{Value: errUnknownField}
+}

--- a/x/rich/eval/vardef.go
+++ b/x/rich/eval/vardef.go
@@ -1,0 +1,21 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package eval
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/x/rich/data"
+)
+
+// vardef must only appear with do() or object() blocks
+// and is a fake "changes.Value" that is not meant to be persisted
+type vardef struct {
+	key   *data.Ref
+	value changes.Value
+}
+
+func (v vardef) Apply(ctx changes.Context, c changes.Change) changes.Value {
+	return nil
+}


### PR DESCRIPTION
This is the third attempt at declarative derived values and is really a rehash of #307

But this form avoids the confusion caused by separate definition types and value types. Instead, methods on value types are implemented via helpers (thereby separating the evaluation part from thee static part).

There are still a few sore points:

1. The code currently does not have any way to easily express lazy evaluations. The earlier approach was imperative (if someone accessed a field, it would get evaluated and maintained) but it may be better to be declarative as to what is lazy-evaluated.

2. The code currently does not have any clear way to do incremental updates  (i.e. if a value changes underneath, exactly what derived data changes and how).  The initial plan is brute force recalcs mostly because this is relatively well understood and the #3  below needs more attention

3. How to integrate changes back from derived data onto original data.  There are three separate issues: a lot of data is lossy (such as calculating a sum of values) and so we need a mechanism to identify that.  This can still offer updates (maybe changing the sum will try to change all individual values a bit).  The second issue is tracking  the dependencies to propagate the changes to. The third issue is chasing refs: I think it is useful  to know when a particular output value is really derived from a ref so the  mutation can intentionally land on the ref or the referred value.